### PR TITLE
Add product docs at genezio.com/docs

### DIFF
--- a/new-landing/public/docs/agentic-commerce/agentic-commerce-readiness.html
+++ b/new-landing/public/docs/agentic-commerce/agentic-commerce-readiness.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Agentic Commerce Readiness | Genezio Docs</title>
+  <meta name="description" content="Agentic Commerce Readiness in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="active" href="agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Agentic Commerce Readiness</h1>
+<p><strong>Agentic commerce</strong> is the shift from people browsing your store to AI agents doing it for them. Shopping assistants inside tools like ChatGPT are starting to browse, compare, and even buy on a user&#39;s behalf. When a shopper asks an assistant to &quot;find me a durable rain jacket under $150 and order it,&quot; the agent — not the person — visits stores, reads product data, and makes the pick.</p>
+<p><strong>Agentic commerce readiness</strong> is how prepared your store is to be understood and acted on by those agents. If an agent can&#39;t read your catalog or reach your endpoints, it can&#39;t recommend you, and it can&#39;t buy from you. Being ready is quickly becoming as important as ranking on Google once was.</p>
+<hr />
+<h2>Why It Matters</h2>
+<p>For most of the web&#39;s history, the customer on the other end was a human reading a page. That assumption is changing. The new customer is often an agent that needs structured, machine-readable information to do its job.</p>
+<p>This matters for an e-commerce brand for a few concrete reasons:</p>
+<ul>
+<li><strong>Agents pick from what they can read.</strong> If your products, prices, and availability aren&#39;t exposed in a machine-readable form, an agent has nothing reliable to work with — and will favor competitors that are easier to parse.</li>
+<li><strong>Selection happens before the shopper sees it.</strong> By the time a recommendation reaches the user, the agent has already narrowed the field. You want to be in that shortlist.</li>
+<li><strong>It compounds with AI Recommendations.</strong> Genezio&#39;s broader mission is making sure AI systems recommend and represent your brand well. Agent-readiness is the commerce-layer extension of that: it&#39;s not just whether AI <em>talks</em> about you, but whether AI can actually <em>transact</em> with you.</li>
+</ul>
+<p>Being agent-ready is no longer a nice-to-have. As more purchases route through assistants, the stores agents can use will win the sale.</p>
+<hr />
+<h2>What UCP Is</h2>
+<p>The <strong>Universal Commerce Protocol (UCP)</strong> is the emerging standard for exposing your store to AI shopping agents. Think of it as a contract between your store and the agents that visit it: a predictable place to find your catalog, your product details, and the endpoints an agent needs to act.</p>
+<p>At a high level, UCP works by publishing a manifest at a well-known location on your site (<code>/.well-known/ucp</code>). That manifest points agents to:</p>
+<ul>
+<li>your <strong>product and catalog data</strong>, in a structured feed they can read,</li>
+<li>the <strong>live endpoints</strong> an agent uses to check details and take action,</li>
+<li>and the metadata that tells an agent what your store supports.</li>
+</ul>
+<p>You don&#39;t need to understand every field to benefit from it. What matters for a marketer is the outcome: a store that speaks UCP is a store that AI agents can confidently recommend and buy from.</p>
+<hr />
+<h2>What Genezio Offers</h2>
+<p>Genezio helps you answer two questions: <em>Is my store ready for agentic commerce?</em> and <em>How do I compare to my competitors?</em></p>
+<p>The core capability is the <strong>UCP Readiness Audit</strong>. It crawls your store&#39;s UCP setup, scores how ready you are, and runs the same check against the competitors you already track in Genezio — so you can see agent-readiness side by side. It also tracks how your readiness changes over time and re-runs automatically after you edit your website, so the picture stays current.</p>
+<p>The audit is surfaced as a dedicated UCP page in the dashboard, with a readiness card that summarizes where you stand at a glance.</p>
+<p>To get hands-on — how to run the audit, what each check means, and how scoring works — see the <a href="ucp-readiness-audit.html">UCP Readiness Audit</a> page.</p>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="ucp-readiness-audit.html">UCP Readiness Audit</a> — run the audit and read your readiness score</li>
+<li><a href="../core-concepts/competitors.html">Competitors</a> — how Genezio tracks the brands you&#39;re benchmarked against</li>
+<li><a href="../insights/competitor-insights.html">Competitor Insights</a> — compare your brand to competitors across AI answers</li>
+<li><a href="../core-concepts/knowledge-base.html">Knowledge Base</a> — the source of truth Genezio builds about your brand</li>
+<li><a href="../tutorials/improve-ai-visibility-for-an-ecommerce-brand.html">Improve AI Visibility for an E-commerce Brand</a> — a practical walkthrough for e-commerce teams</li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/agentic-commerce/ucp-readiness-audit.html
+++ b/new-landing/public/docs/agentic-commerce/ucp-readiness-audit.html
@@ -1,0 +1,130 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>UCP Readiness Audit | Genezio Docs</title>
+  <meta name="description" content="UCP Readiness Audit in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="active" href="ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>UCP Readiness Audit</h1>
+<p>The <strong>UCP Readiness Audit</strong> checks whether your website is ready to be consumed by AI shopping agents. It crawls your store&#39;s setup for the Universal Commerce Protocol (UCP), scores how prepared you are, and runs the same check against your tracked competitors so you can benchmark agent-readiness side by side.</p>
+<p>If you&#39;re new to the concept, start with <a href="agentic-commerce-readiness.html">Agentic Commerce Readiness</a> for the why. This page covers the how: what the audit checks, how scoring works, and how to run it.</p>
+<hr />
+<h2>Why It Matters</h2>
+<p>AI shopping agents can only recommend and buy from stores they can read. The audit turns &quot;are we ready?&quot; from a guess into a concrete, repeatable score — and shows you exactly which parts of your UCP setup are holding you back. Because it also scores your competitors, you can see whether being more agent-ready is an advantage you can win or a gap you need to close.</p>
+<hr />
+<h2>What It Checks</h2>
+<p>The audit looks at three things, in order of how an agent actually encounters your store:</p>
+<ol>
+<li><strong>Manifest completeness.</strong> The audit crawls your site&#39;s <code>/.well-known/ucp</code> manifest — the entry point agents use to discover your store. It checks that the manifest exists and that it contains the information an agent needs to proceed.</li>
+<li><strong>Catalog feed quality.</strong> From the manifest, the audit follows the link to your product/catalog feed and evaluates whether the feed is available and whether its data is complete enough for an agent to compare and select products.</li>
+<li><strong>Live-endpoint probes.</strong> The audit then probes the live endpoints referenced by your setup to confirm they&#39;re reachable and responding, since an agent needs working endpoints to check details and take action.</li>
+</ol>
+<p>Together these mirror the path an agent takes: find the manifest, read the catalog, hit the endpoints.</p>
+<hr />
+<h2>How Scoring Works</h2>
+<p>The audit scores your store against a defined rule set, labeled <strong>U1 through U7</strong>. These rules map to the three areas above:</p>
+<ul>
+<li>rules covering <strong>manifest presence and completeness</strong>,</li>
+<li>rules covering <strong>catalog feed availability and quality</strong>,</li>
+<li>and rules covering <strong>live endpoint reachability</strong>.</li>
+</ul>
+<p>Each rule contributes to an overall readiness score. The result is surfaced on a dedicated UCP page in the dashboard as a <strong>readiness card</strong>, which summarizes where you stand and highlights the rules you&#39;re failing so you know what to fix first.</p>
+<hr />
+<h2>How to Run It</h2>
+<ol>
+<li>Open the <strong>UCP</strong> page in the Genezio dashboard.</li>
+<li>Make sure your brand&#39;s website is set correctly — the audit crawls the live site, so the URL needs to point to your real store. You can check or update this under <strong>Settings -&gt; Brand Details</strong>.</li>
+<li>Run the audit. Genezio crawls the manifest, follows the catalog feed, and probes the live endpoints.</li>
+<li>Review the <strong>readiness card</strong> for your overall score and the U1–U7 rule breakdown.</li>
+</ol>
+<p>You don&#39;t have to run it every time by hand. The audit <strong>re-runs automatically after you edit your website</strong>, so the score reflects your latest changes without extra effort.</p>
+<hr />
+<h2>Score History and Drift</h2>
+<p>The audit keeps a <strong>score history</strong>, so you can see how your readiness changes over time. This drift tracking is useful for catching regressions — for example, if a site change accidentally breaks your manifest or takes an endpoint offline, the readiness score will drop and you&#39;ll see it in the history rather than discovering it when agents stop recommending you.</p>
+<hr />
+<h2>Benchmarking Competitors</h2>
+<p>The audit doesn&#39;t just score your brand. It runs the same checks against the <strong>competitors you track in Genezio</strong>, so you can compare agent-readiness directly.</p>
+<p>This lets you answer questions like:</p>
+<ul>
+<li>Are my competitors already UCP-ready while I&#39;m not?</li>
+<li>Is agent-readiness an advantage I can claim before they do?</li>
+<li>Which specific rules are my competitors passing that I&#39;m failing?</li>
+</ul>
+<p>For more on how Genezio identifies and tracks the brands you&#39;re compared against, see <a href="../core-concepts/competitors.html">Competitors</a> and <a href="../insights/competitor-insights.html">Competitor Insights</a>.</p>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="agentic-commerce-readiness.html">Agentic Commerce Readiness</a> — the concept and why agent-readiness matters</li>
+<li><a href="../core-concepts/competitors.html">Competitors</a> — how Genezio tracks the brands you&#39;re benchmarked against</li>
+<li><a href="../insights/competitor-insights.html">Competitor Insights</a> — compare your brand to competitors across AI answers</li>
+<li><a href="../core-concepts/knowledge-base.html">Knowledge Base</a> — the source of truth Genezio builds about your brand</li>
+<li><a href="../tutorials/improve-ai-visibility-for-an-ecommerce-brand.html">Improve AI Visibility for an E-commerce Brand</a> — a practical walkthrough for e-commerce teams</li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/analysis/creating-scenarios.html
+++ b/new-landing/public/docs/analysis/creating-scenarios.html
@@ -1,0 +1,175 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Creating Scenarios | Genezio Docs</title>
+  <meta name="description" content="Creating Scenarios in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="active" href="creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="running-conversations.html">Running Conversations</a></li><li><a class="" href="playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Creating Scenarios</h1>
+<p>This guide explains how to create and manage <strong>topics and scenarios</strong> in Genezio.</p>
+<p>Scenarios define the situations that Genezio uses when running conversations with AI systems. Well-written scenarios help simulate realistic user questions and improve the quality of visibility analysis.</p>
+<hr />
+<h2>Accessing Topics and Scenarios</h2>
+<p>After signing in to Genezio:</p>
+<ol>
+<li>Open your <strong>Brand</strong>.</li>
+<li>Go to <strong>Settings</strong>.</li>
+<li>Navigate to the <strong>Topics &amp; Scenarios</strong> section.</li>
+</ol>
+<p>Here you will see the current list of topics and the scenarios associated with each topic.</p>
+<p>From this page you can:</p>
+<ul>
+<li>create new topics</li>
+<li>edit or delete existing topics</li>
+<li>create new scenarios</li>
+<li>edit or delete scenarios</li>
+</ul>
+<hr />
+<h2>Creating or Editing Topics</h2>
+<p>Topics represent the <strong>subject areas</strong> where your brand should appear in AI answers.</p>
+<p>When creating a topic, you must select a <strong>Genezio Agent type</strong>:</p>
+<ul>
+<li><strong>Prompter Agent</strong> - a single prompt sent directly to the AI</li>
+<li><strong>Recommender Agent</strong> - a multi-step recommendation conversation</li>
+<li><strong>Comparer Agent</strong> - a conversation comparing multiple brands</li>
+<li><strong>Introspector Agent</strong> - a conversation exploring a specific brand</li>
+</ul>
+<p>Each topic can contain one or more scenarios.</p>
+<hr />
+<h2>Creating Scenarios</h2>
+<p>A <strong>scenario</strong> is a short story that describes a realistic situation — the context, constraints, and goals that lead someone to ask an AI assistant for help.</p>
+<p>A scenario is <strong>not</strong> a prompt or a question. It is a paragraph full of specific details that Genezio will break down into shorter, natural messages and send to the AI system one by one — like a human would in a real conversation.</p>
+<p>A scenario should include:</p>
+<ul>
+<li>the situation the persona is in</li>
+<li>the goal they want to achieve</li>
+<li>specific constraints (budget, team size, technical requirements, compliance needs, etc.)</li>
+</ul>
+<p>A scenario should <strong>not</strong> include persona details like role, age, country, or language. Those are defined separately in the persona and are combined with the scenario at conversation time.</p>
+<p>Example scenario:</p>
+<pre><code>Mary&#39;s team doesn&#39;t have any technical background. They are looking for a marketing automation platform that is easy for a non-technical team to set up and start using without developer help. Their budget is $800/month and she wants her team of 6 to be able to use it in parallel. She is looking for something that is SOC2 compliant.</code></pre>
+<p>From this scenario, Genezio generates natural conversational messages such as:</p>
+<blockquote><p><em><strong>I&#39;m looking for a marketing automation platform that&#39;s easy to set up without any developer help. My team of 6 isn&#39;t very technical. What would you recommend?</strong></em></p></blockquote>
+<blockquote><p><em><strong>Our budget is around $800/month and we need all 6 team members to be able to work in the platform at the same time. Which tools support that?</strong></em></p></blockquote>
+<blockquote><p><em><strong>Does any of these have SOC2 compliance? That&#39;s a requirement for us.</strong></em></p></blockquote>
+<p>The scenario provides the full picture. Genezio turns it into the kind of back-and-forth a real person would have with an AI assistant.</p>
+<hr />
+<h2>Prompter Agent Prompts</h2>
+<p><strong>Prompter Agent topics</strong> use <strong>prompts</strong>, not scenarios. A prompt is a direct question sent <strong>word-for-word</strong> to the AI system, and the conversation consists of a <strong>single interaction</strong>.</p>
+<p>Example prompt:</p>
+<pre><code>What CRM should a startup with a small sales team use to track leads and follow up with customers?</code></pre>
+<p>Prompter Agent prompts represent direct discovery questions that users may ask AI assistants.</p>
+<hr />
+<h2>Custom AI Overview Queries</h2>
+<p>When interacting with <strong>Google AI Overview</strong>, Genezio sends a <strong>search-style query</strong> instead of a conversational prompt.</p>
+<p>For Prompter Agent prompts, Genezio automatically generates this query.</p>
+<p>However, users can <strong>override the generated query</strong> and provide their own search query if needed.</p>
+<p>This allows you to test exactly how specific Google-style searches influence AI Overview results.</p>
+<hr />
+<h2>Automatically Generated Topics and Scenarios</h2>
+<p>Topics and scenarios can also be <strong>automatically generated by Genezio</strong>.</p>
+<p>During onboarding or when expanding analysis, the system can suggest:</p>
+<ul>
+<li>relevant topics for your category</li>
+<li>realistic scenarios based on your persona</li>
+</ul>
+<p>You can review and edit these suggestions before using them.</p>
+<hr />
+<h2>Re-Running Conversations</h2>
+<p>Whenever you:</p>
+<ul>
+<li>add a new scenario</li>
+<li>edit an existing scenario</li>
+<li>modify a topic</li>
+</ul>
+<p>Genezio allows you to <strong>re-run the conversations immediately</strong>.</p>
+<p>This makes it easy to test improvements and quickly see how AI systems respond to the updated scenarios.</p>
+<hr />
+<h2>Best Practices</h2>
+<p>Good scenarios typically:</p>
+<ul>
+<li>read like a short story or a brief — not like a question</li>
+<li>describe a clear situation with specific details and constraints</li>
+<li>include a concrete goal the persona is trying to achieve</li>
+<li>mention the persona by name but do not repeat persona details (role, location, language)</li>
+</ul>
+<p>Scenarios that are too vague or abstract may produce responses that do not mention brands, which lowers scenario relevance.</p>
+<p>Avoid writing scenarios that look like prompts. For example:</p>
+<p><strong>Bad:</strong> <code>What is the best CRM for startups?</code></p>
+<p><strong>Good:</strong> <code>John&#39;s team of three has been tracking leads in a spreadsheet but they are losing follow-ups as inbound volume grows. They need a simple CRM that integrates with Gmail and costs under $50/user/month.</code></p>
+<hr />
+<h2>Next Steps</h2>
+<p>To understand how scenarios turn into AI interactions, see:</p>
+<ul>
+<li><a href="../core-concepts/scenarios.html">Core Concepts -&gt; Scenarios</a></li>
+<li><a href="../core-concepts/conversations.html">Core Concepts -&gt; Conversations</a></li>
+</ul>
+<p>These pages explain how Genezio converts scenarios into conversations and analyzes the results.</p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/analysis/playground.html
+++ b/new-landing/public/docs/analysis/playground.html
@@ -1,0 +1,139 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Playground | Genezio Docs</title>
+  <meta name="description" content="Playground in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="running-conversations.html">Running Conversations</a></li><li><a class="active" href="playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Playground</h1>
+<p>The <strong>Playground</strong> is a sandbox for running one-off LLM conversations that <strong>do not affect your visibility or recommendation metrics</strong>.</p>
+<p>It exists so you can explore, test, and demo without polluting the measurements that drive the rest of the platform.</p>
+<hr />
+<h2>Why the Playground Exists</h2>
+<p>Every scenario Genezio runs as part of its daily schedule feeds into your <strong>AI Recommendations</strong>, <strong>AI Visibility</strong>, and the other KPIs the platform reports.</p>
+<p>That&#39;s the right behavior for measurement — but it&#39;s the wrong behavior when you want to:</p>
+<ul>
+<li>test how a new persona will behave <strong>before</strong> committing it to a scenario</li>
+<li>run an ad-hoc investigation (&quot;let me just ask ChatGPT this one thing as a 35-year-old marketer in Germany&quot;)</li>
+<li>try a wording variation before turning it into a real scenario</li>
+<li>run a live demo without changing the customer&#39;s numbers</li>
+</ul>
+<p>The Playground separates <strong>exploration from measurement</strong>. Anything you run there stays out of your reported metrics.</p>
+<hr />
+<h2>What You Can Configure</h2>
+<p>When you start a Playground run, you choose:</p>
+<ul>
+<li>the <strong>answer engine</strong> (any supported answer engine)</li>
+<li>the <strong>persona</strong> to run as (including their language and location)</li>
+<li>the <strong>Agent type</strong> — Prompter, Recommender, Comparer, or Introspector — which determines how the conversation is structured</li>
+<li>the <strong>language</strong> for the run</li>
+</ul>
+<p>Genezio then executes a <strong>full multi-step Agent conversation</strong>, the same way it would for a real scenario — just outside of metric collection.</p>
+<hr />
+<h2>Where to Find It</h2>
+<p>The Playground is accessible from the <strong>Settings</strong> screen.</p>
+<p>You can also <strong>load a specific scenario</strong> into the Playground from its scenario detail view. This is useful when you want to re-run an existing scenario with a different persona, engine, or wording — without disturbing the metrics that the original scenario contributes to.</p>
+<hr />
+<h2>History and Auto-Cleaning</h2>
+<p>Every Playground run is saved to a <strong>history view</strong> so you can:</p>
+<ul>
+<li>compare attempts side by side</li>
+<li>return to a past run</li>
+<li>iterate on persona, wording, or engine choices</li>
+</ul>
+<p>Older Playground messages are <strong>auto-cleaned</strong> to keep the history tidy. Treat the Playground as a working sandbox, not a long-term archive — if a run produces something you want to preserve, promote it into a real scenario, capture the findings in a brief, or send it to the <a href="../geo-assistant/geo-assistant.html">Geo Assistant</a> for analysis.</p>
+<hr />
+<h2>Typical Workflows</h2>
+<p><strong>Test a new persona before committing.</strong> Draft a persona, run a few Playground conversations against it, see how answer engines respond, then promote it to a real persona once you&#39;re happy with the shape.</p>
+<p><strong>Investigate a hypothesis.</strong> &quot;What does ChatGPT recommend in our category to a buyer with constraint X?&quot; Fire one Playground run; read the answer; refine if needed.</p>
+<p><strong>Pre-flight a scenario change.</strong> Load an existing scenario into the Playground, tweak the wording, and verify the AI response looks the way you expect before saving the change to the real scenario.</p>
+<p><strong>Run a demo.</strong> During a sales or stakeholder demo, show live LLM responses for the customer&#39;s brand without altering their measured numbers.</p>
+<hr />
+<h2>Playground vs. Scheduled Scenarios</h2>
+<table>
+<thead><tr><th style="text-align:left"></th><th style="text-align:left">Playground</th><th style="text-align:left">Scheduled scenarios</th></tr></thead>
+<tbody>
+<tr><td style="text-align:left">Counts toward AI Recommendations / Visibility</td><td style="text-align:left">No</td><td style="text-align:left">Yes</td></tr>
+<tr><td style="text-align:left">Runs on a daily schedule</td><td style="text-align:left">No (manual)</td><td style="text-align:left">Yes</td></tr>
+<tr><td style="text-align:left">Full multi-step Agent conversation</td><td style="text-align:left">Yes</td><td style="text-align:left">Yes</td></tr>
+<tr><td style="text-align:left">Saved in history</td><td style="text-align:left">Yes (auto-cleaned over time)</td><td style="text-align:left">Yes (permanent)</td></tr>
+<tr><td style="text-align:left">Suitable for testing personas, demos, ad-hoc questions</td><td style="text-align:left">Yes</td><td style="text-align:left">No</td></tr>
+<tr><td style="text-align:left">Suitable for measuring visibility over time</td><td style="text-align:left">No</td><td style="text-align:left">Yes</td></tr>
+</tbody>
+</table>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="creating-scenarios.html">Creating Scenarios</a></li>
+<li><a href="selecting-answer-engines.html">Selecting Answer Engines</a></li>
+<li><a href="running-conversations.html">Running Conversations</a></li>
+<li><a href="../core-concepts/personas.html">Core Concepts -&gt; Personas</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/analysis/running-conversations.html
+++ b/new-landing/public/docs/analysis/running-conversations.html
@@ -1,0 +1,194 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Running Conversations | Genezio Docs</title>
+  <meta name="description" content="Running Conversations in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="active" href="running-conversations.html">Running Conversations</a></li><li><a class="" href="playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Running Conversations</h1>
+<p>This guide explains how Genezio runs conversations and how the results are generated.</p>
+<p>Conversations are the core mechanism Genezio uses to measure how AI systems talk about your brand and your competitors.</p>
+<hr />
+<h2>Conversation Execution</h2>
+<p>Genezio runs conversations automatically on a <strong>daily schedule</strong>.</p>
+<p>Each day, the system executes:</p>
+<ul>
+<li>every <strong>scenario</strong></li>
+<li>for every selected <strong>answer engine</strong></li>
+</ul>
+<p>This means that if you have:</p>
+<ul>
+<li>10 scenarios</li>
+<li>4 answer engines selected</li>
+</ul>
+<p>Genezio will run <strong>40 conversations per day</strong>.</p>
+<p>Each of these conversations is stored and analyzed independently.</p>
+<hr />
+<h2>Persona Influence</h2>
+<p>Most conversations are influenced by the <strong>persona</strong> associated with the topic.</p>
+<p>When a topic has a persona assigned, conversations for that topic run:</p>
+<ul>
+<li>the AI interaction is written <strong>as that persona</strong></li>
+<li>the conversation is executed in the <strong>persona&#39;s language</strong></li>
+<li>the interaction is run <strong>from the persona&#39;s geographic location</strong></li>
+</ul>
+<p>This ensures that the AI system responds as if a real user from that context asked the question. Different personas may receive different answers from the same AI system.</p>
+<p><strong>Introspector topics are an exception</strong> — they can run with or without a persona. When no persona is assigned, the conversation simply asks the answer engine to describe the brand directly, with no audience overlay. See <a href="../genezio-agents/introspector-agent.html">Introspector Agent</a> for when each option makes sense.</p>
+<p>For example, a student, a startup founder, and a corporate buyer asking about the same product category may receive different recommendations.</p>
+<hr />
+<h2>How Conversations Are Generated</h2>
+<p>Multi-turn conversations are now driven by a <strong>two-agent conversation driver</strong>: a <strong>planner</strong> agent and a <strong>replier</strong> agent working as a pair. The planner decides what the simulated user should ask next, and the replier plays the user&#39;s side of the exchange with the answer engine.</p>
+<p>Using two agents instead of a single driver produces more realistic, natural multi-turn conversations — each follow-up question reads like something a real person would actually ask, rather than a scripted continuation.</p>
+<p>This applies to the <strong>multi-step agent types</strong> — <strong>Recommender</strong>, <strong>Comparer</strong>, and <strong>Introspector</strong>, which build up an answer over several turns. <strong>Prompter</strong> is the exception: it sends its single prompt <strong>as-is</strong>, with no planner or replier in the loop.</p>
+<hr />
+<h2>Why Conversations Run Daily</h2>
+<p>AI systems evolve continuously. Their answers may change because:</p>
+<ul>
+<li>models are updated</li>
+<li>sources on the web change</li>
+<li>new content appears</li>
+<li>the retrieval system changes</li>
+</ul>
+<p>Running conversations daily allows Genezio to track how answers evolve over time and detect changes in <strong>AI Recommendations and Visibility</strong>.</p>
+<hr />
+<h2>What Happens During a Conversation</h2>
+<p>When a conversation runs, Genezio performs several steps:</p>
+<ol>
+<li>The system selects a <strong>scenario</strong>.</li>
+<li>The conversation is executed against a selected <strong>answer engine</strong>.</li>
+<li>Genezio captures the full response from the AI system.</li>
+<li>The response is analyzed and structured data is extracted.</li>
+</ol>
+<p>This analysis produces several key signals used throughout the platform.</p>
+<hr />
+<h2>Data Extracted from Conversations</h2>
+<p>Each conversation exposes multiple layers of analysis.</p>
+<h3>Query Fanouts</h3>
+<p>The additional searches the AI system performs internally while constructing an answer.</p>
+<p>Follow-up searches (called query fanouts) reveal how the AI system explores the topic.</p>
+<hr />
+<h3>Citations</h3>
+<p>The webpages (sources) referenced by the AI system when generating the answer.</p>
+<p>These sources help explain where the information in the response came from.</p>
+<hr />
+<h3>Perceptions</h3>
+<p>Individual claims extracted from the AI response.</p>
+<p>Perceptions allow Genezio to evaluate the accuracy of what answer engines say about your brand and compare narratives across conversations.</p>
+<hr />
+<h3>Competitors</h3>
+<p>Brands mentioned in the same response as your brand are automatically detected and tracked as competitors.</p>
+<hr />
+<h3>Competitive Insights (Comparer Conversations)</h3>
+<p>When you run Comparer conversations, Genezio analyzes how answer engines frame your brand against specific competitors. From these conversations, you can:</p>
+<ul>
+<li>Understand which strengths and weaknesses answer engines associate with each brand</li>
+<li>Identify opportunities where competitors are vulnerable</li>
+<li>Spot threats where competitors are positioned more favorably</li>
+<li>Generate SWOT-style insights to inform your competitive strategy</li>
+</ul>
+<p>The SWOT analysis is extracted automatically and shown inline when you open a Comparer conversation in the conversation drawer, aggregated up to the scenario and topic level, and rolled up across your full landscape in the <strong>Competitors -&gt; SWOT</strong> view. See <a href="../insights/swot-analysis.html">Insights -&gt; SWOT Analysis</a> for details.</p>
+<p>This gives you a clear picture of how AI systems position your brand relative to alternatives — and where to focus your content efforts.</p>
+<hr />
+<h2>Reports in Your Brand&#39;s Language</h2>
+<p>Extracted <strong>perceptions</strong>, <strong>SWOT</strong>, and <strong>AI insights</strong> are generated in the <strong>brand&#39;s own language</strong>, not just English. Teams working in non-English markets get readable, ready-to-share reports without translation.</p>
+<p>A brand&#39;s language is set during <strong>brand setup</strong>.</p>
+<hr />
+<h2>Inspecting Conversations</h2>
+<p>Each conversation can be inspected in the <strong>Conversation Detail View</strong>.</p>
+<p>This view allows you to see:</p>
+<ul>
+<li>the full interaction with the AI system</li>
+<li>the prompts sent to the model</li>
+<li>the responses generated</li>
+<li>detected query fanouts</li>
+<li>extracted citations</li>
+<li>extracted perceptions</li>
+</ul>
+<p>This transparency allows teams to understand exactly <strong>why a brand appeared or did not appear in an AI answer</strong>.</p>
+<hr />
+<h2>Re-running Conversations</h2>
+<p>Conversations are normally executed automatically each day.</p>
+<p>However, they can also be re-run when:</p>
+<ul>
+<li>a scenario is updated</li>
+<li>a new scenario is added</li>
+<li>a topic is modified</li>
+</ul>
+<p>This allows you to quickly test new scenarios and observe how AI systems respond.</p>
+<hr />
+<h2>Next Steps</h2>
+<p>To understand the structure of the data extracted from conversations, see:</p>
+<ul>
+<li><a href="../core-concepts/query-fanouts.html">Core Concepts -&gt; Query Fanouts</a></li>
+<li><a href="../core-concepts/citations.html">Core Concepts -&gt; Citations</a></li>
+<li><a href="../core-concepts/perceptions.html">Core Concepts -&gt; Perceptions</a></li>
+</ul>
+<p>These pages explain how Genezio converts AI responses into structured insights.</p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/analysis/selecting-answer-engines.html
+++ b/new-landing/public/docs/analysis/selecting-answer-engines.html
@@ -1,0 +1,147 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Selecting Answer Engines | Genezio Docs</title>
+  <meta name="description" content="Selecting Answer Engines in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="creating-scenarios.html">Creating Scenarios</a></li><li><a class="active" href="selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="running-conversations.html">Running Conversations</a></li><li><a class="" href="playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Selecting Answer Engines</h1>
+<p>This guide explains how to choose which AI systems Genezio will use when running conversations.</p>
+<p>Genezio can execute scenarios across multiple <strong>answer engines</strong> (AI assistants). Running conversations across different engines allows you to understand how your brand appears across the AI ecosystem.</p>
+<hr />
+<h2>Where to Configure Answer Engines</h2>
+<p>To select which engines Genezio should use:</p>
+<ol>
+<li>Open your <strong>Brand</strong> in Genezio.</li>
+<li>Go to <strong>Settings</strong>.</li>
+<li>Open <strong>Brand Details</strong>.</li>
+<li>Locate the <strong>Answer Engines</strong> section.</li>
+</ol>
+<p>From here you can enable or disable the engines you want Genezio to use when running conversations.</p>
+<hr />
+<h2>Available Engines</h2>
+<p>Genezio currently supports the following answer engines:</p>
+<ul>
+<li>GPT-5.4</li>
+<li>GPT-4.1</li>
+<li>GPT-4o Mini</li>
+<li>ChatGPT</li>
+<li>GPT-4o Search Preview</li>
+<li>Google AI Overview</li>
+<li>Perplexity</li>
+<li>Claude</li>
+<li>Google AI Mode</li>
+<li>Google Gemini</li>
+<li>Microsoft Copilot</li>
+<li>DeepSeek</li>
+<li>Grok</li>
+</ul>
+<p>Each engine may produce different answers, citations, and brand mentions.</p>
+<p>The underlying models are periodically refreshed as providers ship updates (for example, the Gemini models were upgraded to a newer Flash Lite generation), so results reflect current model behavior.</p>
+<p>For most engines, Genezio runs conversations <strong>through the same user interface that a human would use</strong>. In other words, the system interacts with the answer engine the same way a normal user would when typing questions in the product interface. This approach helps reproduce real-world AI interactions as closely as possible.</p>
+<p>Some engines can also be run <strong>API-only</strong>. In these cases, conversations are executed directly through the provider&#39;s API rather than through a user interface.</p>
+<p>Running conversations across multiple engines helps provide a more complete picture of your <strong>AI Recommendations and Visibility</strong>.</p>
+<hr />
+<h2>Customizing Which Engines You Run</h2>
+<p>Brands can now <strong>customize which answer engines they run against</strong>. Instead of a fully self-serve subscription that locked everyone into the same engine list, you choose the <strong>engine mix that fits your brand</strong> — focusing your attention and spend on the AI systems your audience actually uses.</p>
+<p>On top of the brand-level selection, Genezio supports <strong>per-topic LLM filtering</strong>. Individual topics can <strong>override</strong> which engines they run against, so a specific topic can run on a narrower or different set of engines than the brand default.</p>
+<p>This gives marketers two levels of control:</p>
+<ul>
+<li><strong>Brand level</strong> — set the default engine mix that matters most for your brand.</li>
+<li><strong>Topic level</strong> — narrow or change the engines for individual topics, so you can concentrate effort on the engines that matter for each topic.</li>
+</ul>
+<p>For example, you might run your full engine set across your core topics, but limit an experimental or region-specific topic to just the one or two engines that are relevant there.</p>
+<hr />
+<h2>When Changes Take Effect</h2>
+<p>Changes to selected answer engines do not affect conversations immediately.</p>
+<p>Genezio runs conversations in <strong>daily batches</strong>.</p>
+<p>When you modify the engine selection:</p>
+<ul>
+<li>the change is saved immediately</li>
+<li>new conversations using the updated engine list will start in the <strong>next daily batch</strong></li>
+</ul>
+<p>This means that changes will typically become visible <strong>the following day</strong>, once the next batch of conversations has been executed.</p>
+<hr />
+<h2>Why Engine Selection Matters</h2>
+<p>Different AI systems may:</p>
+<ul>
+<li>recommend different brands</li>
+<li>cite different sources</li>
+<li>interpret questions differently</li>
+</ul>
+<p>By selecting multiple engines, you can compare how your brand appears across the AI landscape.</p>
+<hr />
+<h2>Next Steps</h2>
+<p>To understand how conversations are executed across AI systems, see:</p>
+<ul>
+<li><a href="../core-concepts/conversations.html">Core Concepts -&gt; Conversations</a></li>
+</ul>
+<p>This page explains how Genezio runs scenarios against different answer engines and analyzes the responses.</p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/assets/site.css
+++ b/new-landing/public/docs/assets/site.css
@@ -1,0 +1,484 @@
+:root {
+  --bg: #f8f8f2;
+  --surface: #ffffff;
+  --line: #d9dcca;
+  --text: #1f221d;
+  --muted: #5f6559;
+  --accent: #0d5f43;
+  --accent-strong: #08442f;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  color: var(--text);
+  background: radial-gradient(circle at 100% 0, #e8f0dc 0%, var(--bg) 36%);
+  font: 16px/1.6 "Source Sans 3", "Segoe UI", sans-serif;
+}
+
+h1,
+h2,
+h3 {
+  font-family: "Space Grotesk", "Trebuchet MS", sans-serif;
+  line-height: 1.2;
+}
+
+a {
+  color: var(--accent);
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgb(248 248 242 / 95%);
+  border-bottom: 1px solid var(--line);
+}
+
+.topbar-inner {
+  max-width: 1240px;
+  margin: 0 auto;
+  min-height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 20px;
+}
+
+.topbar nav {
+  display: flex;
+  gap: 16px;
+}
+
+.brand {
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.layout {
+  max-width: 1240px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+  gap: 16px;
+  padding: 16px 20px 40px;
+}
+
+.sidebar {
+  position: sticky;
+  top: 82px;
+  align-self: start;
+  max-height: calc(100vh - 96px);
+  overflow: auto;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  border-radius: 12px;
+  padding: 12px;
+}
+
+.search-box {
+  margin-bottom: 12px;
+}
+
+.search-label {
+  display: block;
+  margin-bottom: 6px;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.search-box input,
+#global-search {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 8px;
+}
+
+.nav-group + .nav-group {
+  border-top: 1px solid #edf0e3;
+  padding-top: 12px;
+  margin-top: 12px;
+}
+
+.nav-group h3 {
+  margin: 0 0 6px;
+  font-size: 15px;
+}
+
+.nav-group ul {
+  margin: 0;
+  padding-left: 16px;
+}
+
+.nav-group li {
+  margin: 4px 0;
+}
+
+.nav-group a {
+  color: var(--muted);
+  text-decoration: none;
+}
+
+.nav-group a.active,
+.nav-group h3 a.active,
+.nav-group a:hover {
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+
+.content {
+  border: 1px solid var(--line);
+  background: var(--surface);
+  border-radius: 12px;
+  padding: 20px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 14px 0;
+}
+
+th,
+td {
+  border: 1px solid var(--line);
+  padding: 8px 10px;
+  vertical-align: top;
+}
+
+th {
+  background: #f3f6eb;
+  font-weight: 700;
+}
+
+.task-item {
+  list-style: none;
+  margin-left: -18px;
+}
+
+.task-item label {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.task-item input[type="checkbox"] {
+  margin-top: 4px;
+}
+
+.kicker {
+  margin: 0;
+  color: var(--accent);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 12px;
+}
+
+article header p {
+  color: var(--muted);
+}
+
+.content section {
+  border-top: 1px solid #edf0e3;
+  padding-top: 14px;
+  margin-top: 16px;
+}
+
+.notice {
+  border: 1px solid #d7d5b1;
+  background: #fffde8;
+  border-radius: 10px;
+  padding: 12px;
+}
+
+blockquote {
+  margin: 12px 0;
+  padding: 10px 14px;
+  border-left: 4px solid #c6d0b8;
+  background: #f7faf1;
+  border-radius: 8px;
+}
+
+blockquote p {
+  margin: 0;
+}
+
+blockquote.user-question {
+  border: 1px solid #9ec8b6;
+  border-left: 6px solid #0d5f43;
+  background: linear-gradient(180deg, #eef8f2 0%, #f7fcf9 100%);
+  padding: 12px 14px;
+  position: relative;
+  box-shadow: 0 1px 0 rgb(13 95 67 / 12%);
+}
+
+blockquote.user-question::before {
+  content: "User asks";
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #0d5f43;
+  background: #d8eee3;
+  border: 1px solid #9ec8b6;
+  border-radius: 999px;
+  padding: 2px 8px;
+  margin-bottom: 8px;
+}
+
+blockquote.user-question p {
+  font-size: 20px;
+  line-height: 1.35;
+  font-weight: 700;
+  font-style: italic;
+  color: #123226;
+}
+
+blockquote.query-fanout {
+  border: 1px dashed #9eb8cf;
+  border-left: 6px solid #3f6f9a;
+  background: linear-gradient(180deg, #f0f6fc 0%, #f8fbff 100%);
+  padding: 12px 14px;
+  position: relative;
+}
+
+blockquote.query-fanout::before {
+  content: "Query fanout";
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #274b6b;
+  background: #ddeaf8;
+  border: 1px solid #9eb8cf;
+  border-radius: 999px;
+  padding: 2px 8px;
+  margin-bottom: 8px;
+}
+
+blockquote.query-fanout p {
+  margin: 0;
+  font-size: 18px;
+  line-height: 1.35;
+  font-weight: 700;
+  font-style: italic;
+  color: #1f3f5b;
+}
+
+blockquote.ai-answer {
+  border: 1px solid #c7c7c7;
+  border-left: 6px solid #6b6b6b;
+  background: linear-gradient(180deg, #f4f4f4 0%, #fbfbfb 100%);
+  padding: 12px 14px;
+  position: relative;
+}
+
+blockquote.ai-answer::before {
+  content: "AI answer";
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #3f3f3f;
+  background: #ececec;
+  border: 1px solid #c7c7c7;
+  border-radius: 999px;
+  padding: 2px 8px;
+  margin-bottom: 8px;
+}
+
+li + li {
+  margin-top: 4px;
+}
+
+.section-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.section-grid li {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 12px;
+}
+
+.results-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.results-list li {
+  border-bottom: 1px solid #edf0e3;
+  padding: 8px 0;
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.results-list span {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.home-main {
+  max-width: 860px;
+  margin: 48px auto;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--surface);
+  padding: 24px;
+}
+
+.button {
+  text-decoration: none;
+  display: inline-block;
+  background: var(--accent);
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: 999px;
+  font-weight: 700;
+}
+
+/* Hamburger toggle & sidebar header — hidden on desktop */
+.sidebar-toggle,
+.sidebar-header {
+  display: none;
+  background: none;
+  padding: 6px 10px;
+  cursor: pointer;
+  font-size: 22px;
+  line-height: 1;
+  color: var(--text);
+}
+
+pre {
+  overflow-x: auto;
+}
+
+@media (max-width: 980px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar-toggle {
+    display: block;
+  }
+
+  .sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 300px;
+    max-width: 85vw;
+    height: 100vh;
+    height: 100dvh;
+    max-height: none;
+    z-index: 100;
+    border-radius: 0;
+    border: none;
+    border-right: 1px solid var(--line);
+    transform: translateX(-100%);
+    transition: transform 0.25s ease;
+    overflow-y: scroll;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
+    padding-top: 0;
+    align-self: auto;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .sidebar-header {
+    display: block;
+    padding: 16px 14px 12px;
+    flex-shrink: 0;
+  }
+
+  .sidebar-header .sidebar-title {
+    font-family: "Space Grotesk", "Trebuchet MS", sans-serif;
+    font-size: 17px;
+    font-weight: 700;
+    color: var(--text);
+    margin: 0;
+  }
+
+  .sidebar-close {
+    display: none;
+  }
+
+  .sidebar-nav {
+    flex: 1;
+    overflow-y: scroll;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
+    padding: 12px;
+  }
+
+  .sidebar.open {
+    transform: translateX(0);
+  }
+
+  body.sidebar-open {
+    overflow: hidden;
+    position: fixed;
+    width: 100%;
+  }
+
+  .sidebar-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 99;
+    background: rgba(0, 0, 0, 0.35);
+  }
+
+  .sidebar-overlay.open {
+    display: block;
+  }
+
+  .content {
+    padding: 16px 14px;
+    border-radius: 8px;
+  }
+
+  table {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .section-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .home-main {
+    margin: 16px;
+    padding: 16px;
+  }
+
+  blockquote.user-question p {
+    font-size: 17px;
+  }
+
+  blockquote.query-fanout p {
+    font-size: 16px;
+  }
+}

--- a/new-landing/public/docs/content-hub/briefs.html
+++ b/new-landing/public/docs/content-hub/briefs.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Briefs | Genezio Docs</title>
+  <meta name="description" content="Briefs in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="content-hub.html">Content Hub</a></li><li><a class="" href="from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="active" href="briefs.html">Briefs</a></li><li><a class="" href="content-analysis.html">Content Analysis</a></li><li><a class="" href="editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Briefs</h1>
+<p>A <strong>brief</strong> is a lightweight, structured outline of a piece of content — what it should cover, who it&#39;s for, and how it should be written — without committing to a finished article.</p>
+<p>Briefs are the fastest path from idea to outline inside Content Hub. They&#39;re designed to be handed off to a writer, editor, or external agency, or to act as a structured starting point you can later expand into a full article.</p>
+<hr />
+<h2>Why Briefs Exist</h2>
+<p>Generating a complete article isn&#39;t always the right first step.</p>
+<p>You may want to:</p>
+<ul>
+<li>hand the work off to an in-house writer or external agency</li>
+<li>align on direction before investing in a full draft</li>
+<li>capture intent quickly while it&#39;s fresh, then come back to it later</li>
+</ul>
+<p>Briefs let you turn an idea into a structured spec in a single pass — without drafting full content just to start the conversation.</p>
+<hr />
+<h2>What&#39;s in a Brief</h2>
+<p>A brief is a structured document that includes:</p>
+<ul>
+<li><strong>Target audience</strong> — who the content is for</li>
+<li><strong>Tone of voice</strong> — how it should read</li>
+<li><strong>Keywords</strong> — terms the content should rank for and reinforce</li>
+<li><strong>Competitors</strong> — brands the content should position against or differentiate from</li>
+<li><strong>Scenarios</strong> — the user scenarios the content should address (you can select multiple, so a single brief can target several intents at once)</li>
+<li><strong>Additional instructions</strong> — any extra guidance for the writer or the next step in the workflow</li>
+</ul>
+<p>Together, these fields produce a spec that can be acted on by a person or by Genezio itself.</p>
+<hr />
+<h2>Creating a Brief</h2>
+<p>To create a brief:</p>
+<ol>
+<li>Open <strong>Content Hub</strong>.</li>
+<li>Click <strong>New Content</strong>.</li>
+<li>Choose <strong>Brief</strong> as the content type.</li>
+<li>Fill in the brief&#39;s fields (audience, tone, keywords, competitors, scenarios, additional instructions).</li>
+<li>Generate the brief.</li>
+</ol>
+<p>The <strong>New Content</strong> entry point (previously labeled &quot;New Article&quot;) now creates either a brief or a full article, depending on what you select.</p>
+<hr />
+<h2>Refining a Brief</h2>
+<p>Each brief has its own <strong>chat interface</strong> for iterative refinement.</p>
+<p>You can ask Genezio to:</p>
+<ul>
+<li>tighten or expand specific sections</li>
+<li>shift the tone</li>
+<li>add or remove competitors and scenarios</li>
+<li>sharpen the audience targeting</li>
+<li>adjust the keywords</li>
+</ul>
+<p>This works the same way as conversational editing for articles — the brief is a working document you can talk to until it&#39;s ready to hand off.</p>
+<hr />
+<h2>Briefs and Articles, Side by Side</h2>
+<p>Briefs live alongside articles in your Content Hub library. You can browse, filter, and open them from the same place.</p>
+<p>When you&#39;re ready to move from outline to draft, a brief can be <strong>converted into an article</strong>. The brief&#39;s structure — audience, tone, keywords, scenarios, instructions — becomes the starting point for the article generation, so you don&#39;t have to re-enter context.</p>
+<hr />
+<h2>Templates and Briefs</h2>
+<p>Briefs respect Content Hub <strong>templates</strong>. If you&#39;ve uploaded or selected a template, new briefs inherit its structure automatically — useful for teams that produce briefs in a consistent shape (for example, a standard brief format every external agency receives).</p>
+<p>See <a href="content-hub.html">Content Hub</a> for how templates work.</p>
+<hr />
+<h2>When to Use a Brief vs. an Article</h2>
+<table>
+<thead><tr><th style="text-align:left">Use a brief when...</th><th style="text-align:left">Use an article when...</th></tr></thead>
+<tbody>
+<tr><td style="text-align:left">You&#39;re handing work off to a writer or agency</td><td style="text-align:left">You want Genezio to produce the finished draft</td></tr>
+<tr><td style="text-align:left">You want to capture intent quickly</td><td style="text-align:left">You&#39;re ready to commit to a full piece</td></tr>
+<tr><td style="text-align:left">You&#39;re still aligning on direction</td><td style="text-align:left">The direction is already clear</td></tr>
+<tr><td style="text-align:left">You want a reusable spec</td><td style="text-align:left">You want a publishable asset</td></tr>
+</tbody>
+</table>
+<p>Both start from the same <strong>New Content</strong> entry point, and a brief can be converted into an article when you&#39;re ready.</p>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="content-hub.html">Content Hub</a></li>
+<li><a href="generating-articles.html">Generating Articles</a></li>
+<li><a href="selecting-target-audience.html">Selecting Target Audience</a></li>
+<li><a href="selecting-tone-of-voice.html">Selecting Tone of Voice</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/content-hub/content-analysis.html
+++ b/new-landing/public/docs/content-hub/content-analysis.html
@@ -1,0 +1,152 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Content Analysis | Genezio Docs</title>
+  <meta name="description" content="Content Analysis in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="content-hub.html">Content Hub</a></li><li><a class="" href="from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="briefs.html">Briefs</a></li><li><a class="active" href="content-analysis.html">Content Analysis</a></li><li><a class="" href="editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Content Analysis</h1>
+<p><strong>Content Analysis</strong> scores any page for how well it&#39;s optimized for AI-driven answer engines. Point it at a URL, a Genezio article, or a document you&#39;ve drafted, and it tells you how likely the page is to be cited by an answer engine — and what to fix to improve that.</p>
+<p>It&#39;s the input side of the loop. The rest of the platform measures what answer engines say about your brand; Content Analysis measures the pages on your side that they read.</p>
+<hr />
+<h2>Why It Exists</h2>
+<p>For most of the platform, the unit of analysis is the <strong>answer</strong> — what ChatGPT, Perplexity, Claude, and others say about your brand and competitors. That tells you whether you&#39;re being recommended, cited, or ignored.</p>
+<p>But the cause of those answers is on <strong>your side</strong>: the pages on your site (and the documents you publish) that answer engines crawl, retrieve, and quote. Content Analysis gives you a way to evaluate those pages directly:</p>
+<ul>
+<li>Which pages are ready to be cited by an answer engine?</li>
+<li>Which ones aren&#39;t, and why?</li>
+<li>What specifically should you change to fix them?</li>
+</ul>
+<p>Pages you improve here should later show up as citations in your dashboards — closing the loop between input quality and measured visibility.</p>
+<hr />
+<h2>What You Can Analyze</h2>
+<p>Content Analysis accepts every common starting point as a first-class input:</p>
+<ul>
+<li>a <strong>URL</strong> — any public page on your site (or elsewhere)</li>
+<li>a <strong>document</strong> — uploaded directly</li>
+<li>an <strong>existing Genezio article</strong> — any article in your Content Hub library</li>
+</ul>
+<p>This means you can run Content Analysis at any point in the content lifecycle: before publishing, after publishing, on a draft an agency sent you, or on a competitor&#39;s published page.</p>
+<hr />
+<h2>What You Get Back</h2>
+<p>Each analysis returns:</p>
+<h3>An Overall Score</h3>
+<p>A single headline score that tells you, at a glance, how citable the page is for answer engines.</p>
+<h3>Per-Dimension Scores</h3>
+<p>The overall score is broken down into the dimensions that drive it:</p>
+<ul>
+<li><strong>Readability</strong> — how cleanly the page reads, including sentence structure and clarity</li>
+<li><strong>Structure</strong> — heading hierarchy, sections, lists, tables, and other signals answer engines use to navigate content</li>
+<li><strong>Claim-supporting signals</strong> — whether claims in the content are backed by evidence answer engines can recognize (data, sources, examples)</li>
+<li><strong>Citability</strong> — how likely an answer engine is to pick this page as a source in a response</li>
+</ul>
+<p>Seeing both the overall score and the breakdown lets you target the dimension that&#39;s holding the page back, rather than guessing.</p>
+<h3>Actionable Recommendations</h3>
+<p>Alongside the scores, Content Analysis surfaces <strong>specific recommendations</strong> for what to change — for example, breaking up a long paragraph, adding a comparison table, surfacing a missing definition, or strengthening a claim with a source.</p>
+<p>The recommendations are tied to the dimension they would improve, so you can prioritize the fixes that move the score the most.</p>
+<hr />
+<h2>A Typical Workflow</h2>
+<p>Content Analysis is designed for a daily workflow, not one-off reports. The natural loop is:</p>
+<ol>
+<li><strong>Run the analysis</strong> — paste a URL, upload a document, or pick an existing article from Content Hub.</li>
+<li><strong>Read the overall score and the breakdown</strong> — see which dimension is weakest.</li>
+<li><strong>Import as a Content Hub draft</strong> — for external inputs (URL or uploaded document), click <strong>Import as Hub draft</strong> directly from the analysis result. The content becomes a regular Content Hub article you can edit.</li>
+<li><strong>Apply the recommendations</strong> — inside the Content Hub editor, fix the issues the analysis flagged.</li>
+<li><strong>Re-analyze from inside the draft</strong> — Content Analysis runs directly on the Hub draft, so you can see the new score without leaving the editor.</li>
+<li><strong>Iterate</strong> — repeat fix → re-analyze until the score is where you want it.</li>
+<li><strong>Publish (or re-publish)</strong> — and watch your dashboards for new citations of the improved page.</li>
+</ol>
+<p>The <strong>Import as Hub draft</strong> action turns Content Analysis from a dead-end report into the <strong>front door to content production</strong>: every common starting point flows directly into the edit-and-improve loop.</p>
+<hr />
+<h2>Content Analysis and the Rest of the Platform</h2>
+<p>Content Analysis is the first piece of the platform that <strong>actively helps you improve</strong> AI visibility rather than just observing it.</p>
+<p>It pairs naturally with the rest of Content Hub:</p>
+<ul>
+<li>Generate or refine an article in Content Hub</li>
+<li>Run Content Analysis on the draft before publishing</li>
+<li>Apply the recommendations</li>
+<li>Publish, then track citation appearances on your dashboards</li>
+</ul>
+<p>And with the <a href="../geo-assistant/geo-assistant.html">Geo Assistant</a>:</p>
+<ul>
+<li>Geo can point you at low-citability pages worth analyzing</li>
+<li>After analysis, you can send results to Geo for follow-up questions (&quot;which of these recommendations would help most for topic X?&quot;)</li>
+</ul>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="content-hub.html">Content Hub</a></li>
+<li><a href="generating-articles.html">Generating Articles</a></li>
+<li><a href="briefs.html">Briefs</a></li>
+<li><a href="editing-articles.html">Editing Articles</a></li>
+<li><a href="publishing-content.html">Publishing Content</a></li>
+<li><a href="../core-concepts/citations.html">Core Concepts -&gt; Citations</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/content-hub/content-hub.html
+++ b/new-landing/public/docs/content-hub/content-hub.html
@@ -1,0 +1,208 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Content Hub | Genezio Docs</title>
+  <meta name="description" content="Content Hub in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="active" href="content-hub.html">Content Hub</a></li><li><a class="" href="from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="briefs.html">Briefs</a></li><li><a class="" href="content-analysis.html">Content Analysis</a></li><li><a class="" href="editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Content Hub</h1>
+<p>The <strong>Content Hub</strong> is where you can create AI-assisted articles designed to improve your brand&#39;s visibility in AI systems.</p>
+<p>These articles are typically created to address opportunities discovered by <strong>Actionable Insights</strong>. In many cases, an insight will recommend creating specific content to strengthen your brand&#39;s presence in AI answers.</p>
+<p>For example, an insight may suggest:</p>
+<ul>
+<li>creating an article explaining a specific product</li>
+<li>publishing a comparison page</li>
+<li>writing a guide addressing a frequently searched scenario</li>
+</ul>
+<p>The Content Hub allows you to generate, edit, refine, and publish these articles. You can also create <strong>briefs</strong> — structured outlines you can hand off to a writer or agency — from the same entry point. See <a href="briefs.html">Briefs</a> for details.</p>
+<hr />
+<h2>Why Content Matters for AI Recommendations</h2>
+<p>AI systems build their answers from information available on the web.</p>
+<p>When authoritative content exists that clearly explains a product, compares options, or answers common questions, AI systems are more likely to reference it.</p>
+<p>The Content Hub helps you create <strong>content specifically designed to influence AI answers</strong>.</p>
+<hr />
+<h2>Creating a New Article</h2>
+<p>To create an article:</p>
+<ol>
+<li>Open <strong>Content Hub</strong>.</li>
+<li>Click <strong>New Content</strong>.</li>
+<li>Choose <strong>Article</strong> as the content type. (Selecting <strong>Brief</strong> instead produces a structured outline — see <a href="briefs.html">Briefs</a>.)</li>
+</ol>
+<p>The <strong>New Content</strong> button has replaced the previous &quot;New Article&quot; button, because that entry point now creates either a brief or an article.</p>
+<p>The article creation process consists of several steps.</p>
+<hr />
+<h3>1. Topic &amp; Scenarios</h3>
+<p>First, select the <strong>topic</strong> and one or more <strong>scenarios</strong> the article should address.</p>
+<p>These come from the same topics and scenarios used when running conversations.</p>
+<p>You can pick <strong>multiple scenarios</strong> for a single piece of content, so one asset can target several user intents at once — useful when a single page (for example, a comparison or FAQ) naturally answers more than one scenario.</p>
+<p>This ensures the article is aligned with <strong>real user questions</strong> that AI systems already encounter.</p>
+<p>You can also choose the <strong>article type</strong> (for example, blog post) and apply a <strong>template</strong> (see Templates below).</p>
+<hr />
+<h3>2. Style &amp; Length</h3>
+<p>Next, configure how the article should be written.</p>
+<p>You can specify:</p>
+<ul>
+<li><strong>Tone of voice</strong> (for example: professional, friendly, analytical)</li>
+<li><strong>Content length</strong> (short, medium, long, or in-depth)</li>
+<li><strong>Language</strong></li>
+</ul>
+<p>These settings help tailor the article to your target audience.</p>
+<hr />
+<h3>3. Additional Details</h3>
+<p>Finally, you can provide additional context to guide the AI.</p>
+<p>Examples include:</p>
+<ul>
+<li><strong>Target audience</strong></li>
+<li><strong>Focus follow-up searches (called query fanouts)</strong> (specific search queries the article should address)</li>
+<li><strong>Website URLs</strong> that should be used as reference sources</li>
+<li><strong>Additional instructions</strong> to influence the writing style or focus</li>
+</ul>
+<p>Once these parameters are configured, you can generate the article.</p>
+<hr />
+<h2>Templates</h2>
+<p>Content Hub supports <strong>templates</strong> — reusable document structures that new content inherits automatically.</p>
+<p>You can:</p>
+<ul>
+<li><strong>upload your own template documents</strong> to define the shape of a content type</li>
+<li><strong>pick from saved templates</strong> when creating new content</li>
+<li>apply templates to both <strong>articles and briefs</strong></li>
+</ul>
+<p>Templates are useful for teams that produce content with a consistent shape — case studies, comparison pages, FAQ pages, landing pages, agency brief formats — by codifying that shape once and reusing it for every new piece. Any new article or brief generated against a template starts from that structure instead of a blank page.</p>
+<hr />
+<h2>Editing Articles</h2>
+<p>Once an article is generated, it opens in the <strong>Content Hub editor</strong>.</p>
+<p>This editor allows you to modify the article directly inside the browser.</p>
+<p>You can:</p>
+<ul>
+<li>edit text</li>
+<li>restructure sections</li>
+<li>adjust formatting</li>
+<li>add or remove content</li>
+</ul>
+<p>The editor behaves like a traditional writing environment, giving you full control over the article. A <strong>rich-text toolbar</strong> is available for headings, lists, links, emphasis, and other formatting — so you don&#39;t have to guess at markup while editing.</p>
+<hr />
+<h2>Conversational Editing</h2>
+<p>In addition to manual editing, the Content Hub provides a <strong>chat interface</strong> that lets you interact with the article conversationally.</p>
+<p>You can ask Genezio to:</p>
+<ul>
+<li>change the tone or style</li>
+<li>expand certain sections</li>
+<li>add new sections</li>
+<li>simplify explanations</li>
+<li>improve SEO</li>
+<li>verify factual information</li>
+</ul>
+<p>At this stage, editing becomes fully conversational - you can simply <strong>chat with the article</strong> and ask the system to improve it.</p>
+<hr />
+<h2>Article Data and Optimization</h2>
+<p>The editor also exposes structured metadata about the article, including:</p>
+<ul>
+<li>SEO metadata</li>
+<li>content score</li>
+<li>keyword density</li>
+<li>internal and external links</li>
+<li>structural analysis</li>
+</ul>
+<p>These signals help ensure the article is well structured and optimized for discoverability.</p>
+<hr />
+<h2>Exporting Articles</h2>
+<p>Articles can be <strong>exported</strong> from the editor.</p>
+<p>Exporting allows you to download the article as a <strong>PDF</strong> so it can be shared, reviewed, or published elsewhere.</p>
+<hr />
+<h2>Publishing Articles</h2>
+<p>When an article is published on your website, you can record its URL in Genezio.</p>
+<p>This allows Genezio to:</p>
+<ul>
+<li>track the article as part of your brand&#39;s content footprint</li>
+<li>monitor whether it appears in AI citations</li>
+<li>include it in the <strong>My Citations</strong> section</li>
+</ul>
+<p>Tracking published articles helps measure whether the new content improves AI Recommendations and Visibility over time.</p>
+<hr />
+<h2>Content Hub and Insights</h2>
+<p>Content Hub is closely connected to <strong>Actionable Insights</strong>.</p>
+<p>Many insights will recommend creating specific articles to address:</p>
+<ul>
+<li>missing topics</li>
+<li>citation gaps</li>
+<li>competitor-dominated queries</li>
+</ul>
+<p>Using the Content Hub makes it possible to quickly turn those insights into <strong>concrete content actions</strong>.</p>
+<hr />
+<h2>Next Steps</h2>
+<p>To understand how insights suggest content opportunities, see:</p>
+<ul>
+<li><a href="../insights/actionable-insights.html">Actionable Insights</a></li>
+</ul>
+<p>To understand how citations track published content, see:</p>
+<ul>
+<li><a href="../core-concepts/citations.html">Core Concepts -&gt; Citations</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/content-hub/editing-articles.html
+++ b/new-landing/public/docs/content-hub/editing-articles.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Editing Articles | Genezio Docs</title>
+  <meta name="description" content="Editing Articles in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="content-hub.html">Content Hub</a></li><li><a class="" href="from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="briefs.html">Briefs</a></li><li><a class="" href="content-analysis.html">Content Analysis</a></li><li><a class="active" href="editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Editing Articles</h1>
+<p>Once an article is generated, it opens in the <strong>Content Hub editor</strong>. The editor is where you refine the draft, adjust structure, and tighten the writing before publishing.</p>
+<hr />
+<h2>The Editor</h2>
+<p>The editor behaves like a traditional writing environment. You can:</p>
+<ul>
+<li>edit text directly</li>
+<li>restructure sections</li>
+<li>add or remove content</li>
+<li>adjust formatting</li>
+</ul>
+<p>Changes are saved as you work, and the article remains in your Content Hub library alongside any other articles and briefs.</p>
+<hr />
+<h2>Rich-Text Toolbar</h2>
+<p>The editor includes a <strong>rich-text toolbar</strong> so formatting is no longer a guessing game.</p>
+<p>The toolbar supports:</p>
+<ul>
+<li>headings (H1, H2, H3, ...)</li>
+<li>bold, italic, and other inline emphasis</li>
+<li>bulleted and numbered lists</li>
+<li>links</li>
+<li>block quotes and code blocks</li>
+</ul>
+<p>You can format content visually without writing markup by hand. This is especially useful when adjusting the structure of an article that&#39;s about to be handed off or published.</p>
+<hr />
+<h2>Conversational Editing</h2>
+<p>In addition to manual editing, the editor provides a <strong>chat interface</strong> that lets you interact with the article conversationally.</p>
+<p>You can ask Genezio to:</p>
+<ul>
+<li>change the tone or style</li>
+<li>expand or simplify sections</li>
+<li>add new sections</li>
+<li>improve SEO</li>
+<li>verify factual claims</li>
+</ul>
+<p>See <a href="chatting-with-your-article.html">Chatting with Your Article</a> for more.</p>
+<hr />
+<h2>Templates</h2>
+<p>If the article was generated against a <strong>template</strong>, the template&#39;s structure is already in place when the editor opens. You can edit within that structure, and headings or sections defined by the template remain in place unless you change them.</p>
+<p>See <a href="content-hub.html">Content Hub</a> for how templates work.</p>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="content-hub.html">Content Hub</a></li>
+<li><a href="briefs.html">Briefs</a></li>
+<li><a href="chatting-with-your-article.html">Chatting with Your Article</a></li>
+<li><a href="publishing-content.html">Publishing Content</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/content-hub/from-data-to-content-strategy.html
+++ b/new-landing/public/docs/content-hub/from-data-to-content-strategy.html
@@ -1,0 +1,155 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>From Data to Content Strategy | Genezio Docs</title>
+  <meta name="description" content="From Data to Content Strategy in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="content-hub.html">Content Hub</a></li><li><a class="active" href="from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="briefs.html">Briefs</a></li><li><a class="" href="content-analysis.html">Content Analysis</a></li><li><a class="" href="editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>From Data to Content Strategy</h1>
+<p><em>Genezio gives you data. This page shows you what to do with it — a practical guide for SEO specialists and content marketers on translating AI visibility signals into a content plan that actually moves the needle.</em></p>
+<hr />
+<h2>The Four Signals Genezio Gives You</h2>
+<p>Every insight in Genezio traces back to four underlying data types. Understanding what each one tells you is the key to knowing what content to create.</p>
+<table>
+<thead><tr><th style="text-align:left">Signal</th><th style="text-align:left">What It Tells You</th></tr></thead>
+<tbody>
+<tr><td style="text-align:left"><strong>📊 AI Recommendations &amp; Visibility %</strong></td><td style="text-align:left">Which topics do you score well on? Which ones have low visibility despite strong SEO rankings? These gaps are your priority list.</td></tr>
+<tr><td style="text-align:left"><strong>🔗 Citations</strong></td><td style="text-align:left">Which URLs is the AI pulling from when it recommends competitors instead of you? Those are the domains you need to get featured on — or outrank.</td></tr>
+<tr><td style="text-align:left"><strong>💬 Perceptions</strong></td><td style="text-align:left">What specific claims does the AI make about your brand? Positive ones to amplify. Negative or outdated ones to correct through better content.</td></tr>
+<tr><td style="text-align:left"><strong>🎯 Actionable Insights</strong></td><td style="text-align:left">Pre-analyzed recommendations from Genezio: growth opportunities, critical gaps, citation sources to target, and positioning issues to fix.</td></tr>
+</tbody>
+</table>
+<hr />
+<h2>Content Playbooks by Signal Type</h2>
+<h3>Playbook 1: Low AI Visibility on a Key Topic</h3>
+<blockquote><p><strong>Signal:</strong> Your Visibility % is under 20% on a topic your SEO already ranks for. <strong>HIGH PRIORITY.</strong></p></blockquote>
+<p><strong>What&#39;s happening:</strong> answer engines know your page exists but don&#39;t trust it enough to cite you in synthesized answers. You might rank #1 on Google but still be absent from ChatGPT&#39;s answer because you&#39;re not referenced by the third-party sources AI pulls from.</p>
+<p><strong>What to create:</strong></p>
+<ul>
+<li>In-depth pillar pages</li>
+<li>FAQ content for the topic</li>
+<li>Guest posts on authoritative sites in the category</li>
+<li>Data studies or original research answer engines love to cite</li>
+</ul>
+<p><strong>SEO specialist tip:</strong> Check Genezio&#39;s Citations section for this topic. The sites AI is currently citing instead of you are your PR and link-building hit list. A single mention from a domain AI trusts can lift your Visibility % within weeks.</p>
+<hr />
+<h3>Playbook 2: Competitor Getting Cited, You Are Not</h3>
+<blockquote><p><strong>Signal:</strong> Citations section shows competitor URLs from sources where you have no presence. <strong>MEDIUM-HIGH PRIORITY.</strong></p></blockquote>
+<p><strong>What&#39;s happening:</strong> When AI answers a question in your category, it references specific third-party sources — review sites, industry blogs, comparison platforms. Your competitor is featured there. You&#39;re not.</p>
+<p><strong>What to create:</strong></p>
+<ul>
+<li>G2 / Capterra / Trustpilot profile optimization</li>
+<li>Contributed articles on the citing domains</li>
+<li>Press coverage in industry publications AI trusts</li>
+<li>Updated case studies to pitch to journalists</li>
+</ul>
+<p><strong>Content marketer tip:</strong> Don&#39;t just pitch your brand — pitch a story. Publications that answer engines cite frequently tend to publish original data, expert roundups, and how-to guides. Create content assets journalists will want to reference.</p>
+<hr />
+<h3>Playbook 3: Negative or Outdated Perceptions</h3>
+<blockquote><p><strong>Signal:</strong> Perceptions analysis shows AI making incorrect or unfavorable claims about your brand. <strong>HIGH PRIORITY.</strong></p></blockquote>
+<p><strong>What&#39;s happening:</strong> answer engines are trained on existing web content. If the web says your product is &quot;hard to set up&quot; or &quot;expensive,&quot; that narrative will persist in AI answers — even if it&#39;s no longer true.</p>
+<p><strong>What to create:</strong></p>
+<ul>
+<li>&quot;New in [Year]&quot; posts directly addressing the outdated claim</li>
+<li>Comparison pages that address the objection head-on</li>
+<li>Customer story content countering the narrative</li>
+<li>Updated review responses on G2/Capterra to shift sentiment</li>
+</ul>
+<p><strong>SEO specialist tip:</strong> Adding FAQPage schema that directly answers &quot;Is [Brand] expensive?&quot; or &quot;Is [Brand] hard to use?&quot; creates structured data answer engines can more easily extract and cite — often overriding older, less structured content.</p>
+<hr />
+<h3>Playbook 4: Growth Opportunity Identified</h3>
+<blockquote><p><strong>Signal:</strong> Actionable Insights surface a topic where competitors rank but the category is underserved. <strong>EXPANSION OPPORTUNITY.</strong></p></blockquote>
+<p><strong>What&#39;s happening:</strong> Genezio detected a scenario set where answer engines consistently recommend brands but the content quality is low, citations are thin, or your brand could realistically compete with a targeted push.</p>
+<p><strong>What to create:</strong></p>
+<ul>
+<li>Dedicated landing pages for the underserved topic</li>
+<li>Comparison content (&quot;Best X for Y use case&quot;)</li>
+<li>Integration or partnership content to expand associations</li>
+<li>Targeted outreach for citations in that specific niche</li>
+</ul>
+<p><strong>Content marketer tip:</strong> Growth opportunities identified by Genezio often map to long-tail topics where a single strong piece of content can establish quick authority. Prioritize these over trying to compete on the most crowded terms.</p>
+<hr />
+<h2>Mapping Agent Types to Content Types</h2>
+<p>Each of Genezio&#39;s five agent types reveals a different content need:</p>
+<table>
+<thead><tr><th style="text-align:left">Agent That Exposed the Gap</th><th style="text-align:left">Content to Create</th><th style="text-align:left">Goal</th></tr></thead>
+<tbody>
+<tr><td style="text-align:left"><strong>Prompter</strong> — not in category discovery answers</td><td style="text-align:left">Category pillar pages, &quot;best of&quot; content, in-depth guides, original data</td><td style="text-align:left">Get AI to associate your brand with the category</td></tr>
+<tr><td style="text-align:left"><strong>Recommender</strong> — not recommended for specific use cases</td><td style="text-align:left">Use-case landing pages, persona-specific content, ROI calculators</td><td style="text-align:left">Be the answer to specific buyer intent queries</td></tr>
+<tr><td style="text-align:left"><strong>Introspector</strong> — AI describes your brand inaccurately</td><td style="text-align:left">Updated About/Product pages, FAQ schema, press coverage, analyst coverage</td><td style="text-align:left">Correct and strengthen how AI describes you</td></tr>
+<tr><td style="text-align:left"><strong>Comparer</strong> — AI frames you unfavorably vs. a competitor</td><td style="text-align:left">&quot;[Brand] vs [Competitor]&quot; comparison pages, migration guides, switcher case studies</td><td style="text-align:left">Control the competitive narrative in AI answers</td></tr>
+<tr><td style="text-align:left"><strong>Fact Checker</strong> — AI states incorrect or unverifiable facts about you</td><td style="text-align:left">Updated product, pricing, and certification pages; corrected third-party listings; authoritative reference content for high-risk claims</td><td style="text-align:left">Make sure the right facts are public, crawlable, and confirmed across answer engines</td></tr>
+</tbody>
+</table>
+<blockquote><p><strong>The 80/20 rule for GEO content:</strong> 80% of your AI visibility lift will come from getting cited by the 3–5 authoritative sources that answer engines in your category trust most. Find those sources in Genezio&#39;s Citations section and make getting featured there your top content priority.</p></blockquote>
+<blockquote><p><strong>For SEO specialists:</strong> GEO content strategy doesn&#39;t replace your SEO strategy — it extends it. Pages that rank well AND appear in AI answers get significantly more total brand exposure than pages that do one or the other. Use Genezio&#39;s data to identify where your existing high-ranking pages are underperforming in AI citations, and optimize those first.</p></blockquote>
+<hr />
+<p><em>Next: <a href="your-first-week.html">Your First Week with Genezio</a></em></p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/core-concepts/brand-recommendation.html
+++ b/new-landing/public/docs/core-concepts/brand-recommendation.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Brand Recommendation | Genezio Docs</title>
+  <meta name="description" content="Brand Recommendation in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="brands.html">Brands</a></li><li><a class="active" href="brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="brand-visibility.html">Brand Visibility</a></li><li><a class="" href="users.html">Users</a></li><li><a class="" href="personas.html">Personas</a></li><li><a class="" href="topics.html">Topics</a></li><li><a class="" href="scenarios.html">Scenarios</a></li><li><a class="" href="topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="conversations.html">Conversations</a></li><li><a class="" href="query-fanouts.html">Query Fanouts</a></li><li><a class="" href="citations.html">Citations</a></li><li><a class="" href="perceptions.html">Perceptions</a></li><li><a class="" href="competitors.html">Competitors</a></li><li><a class="" href="knowledge-base.html">Knowledge Base</a></li><li><a class="" href="products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Brand Recommendation</h1>
+<p>In Genezio, <strong>Brand Recommendation</strong> measures how often answer engines actively recommend your brand when users ask for a solution.</p>
+<p>It answers the most important question for any marketing team:</p>
+<p><strong>When users ask AI assistants to recommend a product or service in your category, how often is your brand the one they suggest?</strong></p>
+<p>Brand Recommendation is expressed as a <strong>percentage of recommendation-focused conversations where the brand is recommended</strong>.</p>
+<hr />
+<h2>What Brand Recommendation Represents</h2>
+<p>When Genezio runs conversations that simulate users looking for recommendations, the answer engine may or may not recommend your brand.</p>
+<p>Examples of being recommended:</p>
+<ul>
+<li>The AI names your brand as a top choice</li>
+<li>The AI lists your brand among its recommended solutions</li>
+<li>The AI suggests your brand as a good fit for the user&#39;s specific needs</li>
+</ul>
+<p>If the brand is actively recommended in the response, that conversation counts as a <strong>recommendation</strong>.</p>
+<p>If the brand is not recommended — even if it&#39;s mentioned in passing — it does not count.</p>
+<hr />
+<h2>How Brand Recommendation Is Calculated</h2>
+<p>Brand Recommendation is calculated as:</p>
+<pre><code>Brand Recommendation = (Conversations where the brand is recommended / Conversations where the brand is visible) x 100</code></pre>
+<p>The denominator is not all conversations — it&#39;s only the ones where your brand actually appeared. This means Brand Recommendation measures your <strong>conversion rate from visibility to recommendation</strong>.</p>
+<h3>Worked Example</h3>
+<p>Say Genezio runs <strong>200 conversations</strong> for your topics:</p>
+<ul>
+<li>Your brand appeared in <strong>80</strong> of them → AI Visibility = 80 / 200 = <strong>40%</strong></li>
+<li>Of those 80 visible conversations, your brand was recommended in <strong>48</strong> → AI Recommendation = 48 / 80 = <strong>60%</strong></li>
+</ul>
+<p>This means:</p>
+<ul>
+<li>Your brand shows up in 40% of all AI conversations (Visibility)</li>
+<li>When it does show up, it gets recommended <strong>60% of the time</strong> (Recommendation)</li>
+<li>The remaining 40% of visible conversations mentioned your brand but didn&#39;t recommend it</li>
+</ul>
+<p>The denominator is <strong>visible conversations, not total conversations</strong>. Recommendation % measures your conversion rate from being mentioned to being the suggested choice.</p>
+<hr />
+<h2>Which Conversations Are Included</h2>
+<p>Brand Recommendation is a <strong>brand-level metric</strong> calculated from conversations where the answer engine decides on its own which brands to recommend, based on the user&#39;s needs.</p>
+<p>The metric is generated from <strong>Recommender Agent</strong> conversations — scenario-driven, multi-step conversations where a persona asks the AI for a recommendation that matches their specific situation.</p>
+<p>Example:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>Recommend CRM tools for early-stage startups with a small sales team.</strong></em></p></blockquote>
+<p>The AI responds with its own choices. If your brand is among them, that&#39;s a recommendation. If it&#39;s not, you&#39;ve lost that opportunity.</p>
+<hr />
+<h3>What About Other Agent Types?</h3>
+<p><strong>Prompter Agent</strong> — Contributes to AI Visibility (brand was mentioned) but does not specifically ask for a recommendation, so it is not used for AI Recommendations.</p>
+<p><strong>Introspector Agent</strong> — Used for narrative analysis and claim accuracy evaluation. Because your brand is named in the question, it doesn&#39;t reflect a genuine recommendation decision.</p>
+<p><strong>Comparer Agent</strong> — This is a <strong>competitive analysis tool</strong>, not a measurement engine. The Comparer uses your brand&#39;s recommendation and visibility data to show how you perform relative to specific competitors. It does not contribute to the calculation of AI Recommendations or AI Visibility.</p>
+<hr />
+<h2>Why Brand Recommendation Matters</h2>
+<p>Brand Recommendation is the closest metric to a <strong>buying decision</strong> in AI search.</p>
+<p>When a user asks an AI assistant <em>&quot;What should I use?&quot;</em> and the AI recommends your brand, that&#39;s the equivalent of a trusted advisor pointing a buyer your way.</p>
+<p>A higher recommendation score means:</p>
+<ul>
+<li>answer engines trust your brand as a strong match for users&#39; needs</li>
+<li>Your brand is actively suggested ahead of competitors</li>
+<li>Users who rely on AI for purchase decisions are being directed to you</li>
+</ul>
+<p>A lower score means competitors are being recommended instead — and you&#39;re losing deals before the buyer even visits your website.</p>
+<hr />
+<h2>Brand Recommendation vs. Brand Visibility</h2>
+<p>These two metrics work together but measure different things:</p>
+<table>
+<thead><tr><th style="text-align:left"></th><th style="text-align:left">Brand Recommendation</th><th style="text-align:left">Brand Visibility</th></tr></thead>
+<tbody>
+<tr><td style="text-align:left"><strong>What it measures</strong></td><td style="text-align:left">Of the conversations where you&#39;re visible, how often are you recommended?</td><td style="text-align:left">How often your brand appears at all in AI answers</td></tr>
+<tr><td style="text-align:left"><strong>Denominator</strong></td><td style="text-align:left">Conversations where brand appeared</td><td style="text-align:left">All eligible conversations</td></tr>
+<tr><td style="text-align:left"><strong>Which conversations</strong></td><td style="text-align:left">Recommender</td><td style="text-align:left">Prompter + Recommender</td></tr>
+<tr><td style="text-align:left"><strong>Why it matters</strong></td><td style="text-align:left">Your conversion rate from presence to purchase intent</td><td style="text-align:left">Measures overall brand presence and awareness</td></tr>
+<tr><td style="text-align:left"><strong>Business analogy</strong></td><td style="text-align:left">Conversion rate — of the people who see you, how many choose you</td><td style="text-align:left">Brand awareness — how many people have heard of you</td></tr>
+</tbody>
+</table>
+<p>A brand can have high visibility (mentioned often) but low recommendation rate (rarely the suggested choice). That gap is your priority — it means answer engines know about you but don&#39;t trust you enough to recommend you.</p>
+<hr />
+<h2>Brand Recommendation Over Time</h2>
+<p>Genezio tracks Brand Recommendation continuously as new conversations are executed.</p>
+<p>This allows teams to observe trends such as:</p>
+<ul>
+<li>increasing recommendations after publishing better comparison content</li>
+<li>competitors gaining or losing recommendation share</li>
+<li>changes in how answer engines evaluate your brand against alternatives</li>
+</ul>
+<p>Monitoring recommendations over time helps you see the direct impact of your marketing work on AI-driven purchase decisions.</p>
+<hr />
+<h2>Next Steps</h2>
+<p>To understand the broader metric of how often your brand appears in AI answers, see:</p>
+<ul>
+<li><a href="brand-visibility.html">Brand Visibility</a></li>
+</ul>
+<p>To see how recommendation rates compare across competitors, see:</p>
+<ul>
+<li><a href="../insights/share-of-voice.html">Insights -&gt; Share of Voice</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/core-concepts/brand-visibility.html
+++ b/new-landing/public/docs/core-concepts/brand-visibility.html
@@ -1,0 +1,170 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Brand Visibility | Genezio Docs</title>
+  <meta name="description" content="Brand Visibility in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="brands.html">Brands</a></li><li><a class="" href="brand-recommendation.html">Brand Recommendation</a></li><li><a class="active" href="brand-visibility.html">Brand Visibility</a></li><li><a class="" href="users.html">Users</a></li><li><a class="" href="personas.html">Personas</a></li><li><a class="" href="topics.html">Topics</a></li><li><a class="" href="scenarios.html">Scenarios</a></li><li><a class="" href="topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="conversations.html">Conversations</a></li><li><a class="" href="query-fanouts.html">Query Fanouts</a></li><li><a class="" href="citations.html">Citations</a></li><li><a class="" href="perceptions.html">Perceptions</a></li><li><a class="" href="competitors.html">Competitors</a></li><li><a class="" href="knowledge-base.html">Knowledge Base</a></li><li><a class="" href="products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Brand Visibility</h1>
+<p>In Genezio, <strong>Brand Visibility</strong> measures how often your brand appears in AI-generated answers.</p>
+<p>It answers a simple question:</p>
+<p><strong>When users ask AI assistants questions related to your category, how often does your brand show up?</strong></p>
+<p>Brand Visibility is expressed as a <strong>percentage of conversations where the brand is mentioned</strong>.</p>
+<hr />
+<h2>What Brand Visibility Represents</h2>
+<p>When Genezio runs conversations with AI systems, the responses may or may not include your brand.</p>
+<p>Examples:</p>
+<ul>
+<li>Your brand is recommended in the answer</li>
+<li>Your brand appears in a comparison</li>
+<li>Your brand is mentioned alongside competitors</li>
+</ul>
+<p>If the brand appears anywhere in the response, that conversation counts as a <strong>visible occurrence</strong>.</p>
+<p>If the brand does not appear, the conversation counts as <strong>not visible</strong>.</p>
+<hr />
+<h2>How Brand Visibility Is Calculated</h2>
+<p>Brand Visibility is calculated as:</p>
+<pre><code>Brand Visibility = (Conversations where the brand appears / Total eligible conversations) x 100</code></pre>
+<p>Example:</p>
+<ul>
+<li>Total conversations analyzed: 100</li>
+<li>Conversations mentioning the brand: 78</li>
+</ul>
+<p>Brand Visibility:</p>
+<pre><code>78%</code></pre>
+<p>This means the brand appears in <strong>78% of AI-generated answers</strong> for the analyzed topics.</p>
+<hr />
+<h2>Which Conversations Are Included</h2>
+<p>Not all Genezio Agent types contribute to Brand Visibility.</p>
+<p>Genezio only includes conversations where the AI system <strong>chooses the brands on its own</strong>, without being biased by the prompt.</p>
+<p>Therefore, only the following Genezio Agent types are used:</p>
+<h3>Prompter Agent</h3>
+<p>Prompter Agent conversations ask a direct discovery question.</p>
+<p>Example:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>What CRM should a startup use?</strong></em></p></blockquote>
+<p>The AI system decides which brands to mention.</p>
+<hr />
+<h3>Recommender Agent</h3>
+<p>Recommender Agent conversations simulate a user asking for recommendations.</p>
+<p>The AI system selects which brands to suggest based on the scenario.</p>
+<hr />
+<h3>Excluded Agent Types</h3>
+<p>Some agent types are <strong>excluded</strong> from Brand Visibility because the brand name appears in the prompt itself.</p>
+<p>These include:</p>
+<p><strong>Introspector Agent</strong></p>
+<p>Example:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>What is HubSpot used for?</strong></em></p></blockquote>
+<p><strong>Comparer Agent</strong></p>
+<p>Example:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>HubSpot vs Salesforce</strong></em></p></blockquote>
+<p>Including these would artificially inflate visibility because the brand is already part of the prompt. The Comparer is a <strong>competitive analysis tool</strong> — it consumes your brand-level KPIs but does not contribute to the calculation of AI Recommendations or AI Visibility. See <a href="brand-recommendation.html">Brand Recommendation</a> for details.</p>
+<hr />
+<h2>Accuracy and Sample Size</h2>
+<p>Brand Visibility is calculated using an <strong>accuracy model</strong>.</p>
+<p>Instead of relying on a fixed number of conversations, Genezio analyzes the <strong>most recent conversations until a reliable accuracy threshold is reached</strong>.</p>
+<p>By default, Genezio calculates visibility using the latest conversations until the estimate reaches a <strong>90% accuracy level</strong>.</p>
+<p>This ensures that the visibility percentage is reliable and trustworthy.</p>
+<hr />
+<h2>Accuracy Range</h2>
+<p>Because Brand Visibility is estimated from a sample of conversations, the result includes an <strong>accuracy range</strong>.</p>
+<p>For example:</p>
+<pre><code>Brand Presence: 78%
+Accuracy range: 54% - 100%
+Accuracy level: 90%</code></pre>
+<p>This means that based on the analyzed conversations, Genezio is <strong>90% confident</strong> that the true visibility of the brand falls within that range.</p>
+<p>As more conversations are executed, the range typically becomes narrower and the estimate becomes more precise.</p>
+<hr />
+<h2>Why Brand Visibility Matters</h2>
+<p>Brand Visibility provides a high-level signal of how AI systems perceive a brand within a category.</p>
+<p>A higher visibility score generally means:</p>
+<ul>
+<li>the brand is frequently recommended</li>
+<li>the brand appears in comparison lists</li>
+<li>the brand is strongly associated with the topic</li>
+</ul>
+<p>A lower score may indicate that competitors dominate AI-generated answers.</p>
+<hr />
+<h2>Brand Visibility Over Time</h2>
+<p>Genezio tracks Brand Visibility continuously as new conversations are executed.</p>
+<p>This allows teams to observe trends such as:</p>
+<ul>
+<li>increasing visibility after publishing new content</li>
+<li>competitors gaining or losing presence</li>
+<li>changes in how AI systems interpret a category</li>
+</ul>
+<p>Monitoring visibility over time helps organizations understand how their presence evolves across AI platforms.</p>
+<hr />
+<h2>Next Steps</h2>
+<p>To understand how visibility compares across brands, see:</p>
+<ul>
+<li><a href="../insights/share-of-voice.html">Insights -&gt; Share of Voice</a></li>
+</ul>
+<p>This page explains how Genezio compares brand visibility across competitors within the same topic.</p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/core-concepts/brands.html
+++ b/new-landing/public/docs/core-concepts/brands.html
@@ -1,0 +1,244 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Brands | Genezio Docs</title>
+  <meta name="description" content="Brands in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="brands.html">Core Concepts</a></h3>
+        <ul><li><a class="active" href="brands.html">Brands</a></li><li><a class="" href="brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="brand-visibility.html">Brand Visibility</a></li><li><a class="" href="users.html">Users</a></li><li><a class="" href="personas.html">Personas</a></li><li><a class="" href="topics.html">Topics</a></li><li><a class="" href="scenarios.html">Scenarios</a></li><li><a class="" href="topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="conversations.html">Conversations</a></li><li><a class="" href="query-fanouts.html">Query Fanouts</a></li><li><a class="" href="citations.html">Citations</a></li><li><a class="" href="perceptions.html">Perceptions</a></li><li><a class="" href="competitors.html">Competitors</a></li><li><a class="" href="knowledge-base.html">Knowledge Base</a></li><li><a class="" href="products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Brands</h1>
+<p>In Genezio, a <strong>brand</strong> represents the organization, product, or service whose visibility you want to measure in AI-generated answers.</p>
+<p>Every analysis in Genezio is centered around a brand. Topics, scenarios, conversations, and insights are all evaluated in relation to how that brand appears in responses generated by AI systems.</p>
+<hr />
+<h2>What a Brand Represents</h2>
+<p>A brand typically corresponds to one of the following:</p>
+<ul>
+<li>a company</li>
+<li>a product</li>
+<li>a service</li>
+<li>a platform</li>
+</ul>
+<p>Examples:</p>
+<ul>
+<li>HubSpot</li>
+<li>Nike</li>
+<li>Stripe</li>
+<li>Notion</li>
+</ul>
+<p>The brand is the entity whose presence you want to monitor when users ask questions to AI assistants such as ChatGPT, Claude, Gemini, or Perplexity.</p>
+<hr />
+<h2>Information Associated With a Brand</h2>
+<p>When you create a brand in Genezio, several pieces of information are collected or generated.</p>
+<h3>Brand Name</h3>
+<p>The official name of the organization, product, or service.</p>
+<p>Example:</p>
+<pre><code>HubSpot</code></pre>
+<p>This name is used when detecting mentions inside AI-generated answers.</p>
+<hr />
+<h3>Website URL</h3>
+<p>The primary website associated with the brand.</p>
+<p>Example:</p>
+<pre><code>https://hubspot.com</code></pre>
+<p>The website helps Genezio understand the brand&#39;s domain and identify citations pointing to the brand&#39;s own content.</p>
+<hr />
+<h3>Brand Description</h3>
+<p>Genezio generates a short description explaining what the brand does and the category it belongs to.</p>
+<p>Example:</p>
+<blockquote><p>HubSpot is a CRM and marketing automation platform designed to help businesses manage customer relationships, marketing campaigns, and sales pipelines.</p></blockquote>
+<p>This description helps the system better understand how the brand should appear in conversations.</p>
+<hr />
+<h3>Customer Profile</h3>
+<p>Each brand also has an associated <strong>customer profile</strong> describing the typical user or buyer.</p>
+<p>Example:</p>
+<ul>
+<li>startup founders</li>
+<li>small business owners</li>
+<li>marketing teams</li>
+</ul>
+<p>This profile helps generate realistic user questions during scenario creation.</p>
+<hr />
+<h2>Why Brands Are Central to Genezio</h2>
+<p>Genezio analyzes AI-generated answers to determine:</p>
+<ul>
+<li>whether the brand appears</li>
+<li>how frequently it appears</li>
+<li>which sources mention the brand</li>
+<li>how the brand is described</li>
+<li>which competitors appear alongside it</li>
+</ul>
+<p>Because of this, the brand acts as the <strong>reference point for all visibility measurements</strong>.</p>
+<p>Every insight-such as visibility scores, share of voice, and competitor analysis-is calculated relative to a specific brand.</p>
+<hr />
+<h2>Multiple Brands</h2>
+<p>An account can contain multiple brands.</p>
+<p>This is useful for:</p>
+<ul>
+<li>agencies managing several clients</li>
+<li>companies tracking multiple products</li>
+<li>organizations monitoring multiple markets</li>
+</ul>
+<p>Each brand has its own topics, scenarios, conversations, and insights.</p>
+<hr />
+<h2>Multi-Product Companies</h2>
+<p>If your company offers multiple distinct products, there are <strong>two ways to model the setup</strong> in Genezio. Picking the right one matters — it shapes how every metric gets reported.</p>
+<h3>Option 1 — Separate Brands per Product</h3>
+<p>Use this approach when each product has its <strong>own brand presence</strong> in answer engines:</p>
+<ul>
+<li>the products are well-known to answer engines <strong>by their product names</strong></li>
+<li>customers refer to them directly by product name (not by the parent company)</li>
+<li>each product has its own distinct competitors</li>
+</ul>
+<p>In this case, model each product as its own brand. Each gets its own topics, scenarios, AI Recommendations and Visibility scores, and competitor landscape.</p>
+<p><strong>Example — Microsoft.</strong> Rather than creating a single &quot;Microsoft&quot; brand:</p>
+<ul>
+<li><strong>Microsoft Word</strong> — competes with Google Docs, Notion, etc.</li>
+<li><strong>Microsoft Excel</strong> — competes with Google Sheets, Airtable, etc.</li>
+<li><strong>Microsoft Teams</strong> — competes with Slack, Zoom, etc.</li>
+</ul>
+<p><strong>Example — Bitdefender.</strong> A cybersecurity company with multiple product lines:</p>
+<ul>
+<li><strong>Bitdefender Total Security</strong> — consumer antivirus, competes with Norton and McAfee</li>
+<li><strong>Bitdefender GravityZone</strong> — enterprise endpoint protection, competes with CrowdStrike and SentinelOne</li>
+</ul>
+<p>Separate brands keep these competitive landscapes distinct.</p>
+<h3>Option 2 — One Brand With Products</h3>
+<p>Use this approach when your <strong>parent brand</strong> is strong but the individual products don&#39;t carry independent brand recognition:</p>
+<ul>
+<li>customers know the company name, not the product names</li>
+<li>answer engines describe the products as offerings of the parent brand</li>
+<li>products often share competitors</li>
+</ul>
+<p>In this case, keep everything as one brand and use Genezio&#39;s <strong>Products</strong> feature to filter the data per product line. A product picker appears in the main header, letting you switch between products — or stay in the brand-wide &quot;all products&quot; view.</p>
+<p>See <a href="products.html">Products</a> for the full setup.</p>
+<h3>When to Use a Single Brand With No Products</h3>
+<p>Use a single brand and skip Products entirely when:</p>
+<ul>
+<li>your company name and product name are the same (e.g., Notion, Stripe, Slack)</li>
+<li>you want to measure overall company-level visibility, not product-level</li>
+<li>your products share the same competitors and buyer persona</li>
+</ul>
+<h3>Quick Decision</h3>
+<table>
+<thead><tr><th style="text-align:left">If...</th><th style="text-align:left">Use</th></tr></thead>
+<tbody>
+<tr><td style="text-align:left">Each product has its own brand recognition and distinct competitors</td><td style="text-align:left"><strong>Separate brands</strong></td></tr>
+<tr><td style="text-align:left">The parent brand is strong; products don&#39;t have independent brand presence</td><td style="text-align:left"><strong>One brand + Products</strong></td></tr>
+<tr><td style="text-align:left">Company and product are the same name</td><td style="text-align:left"><strong>Single brand, no Products</strong></td></tr>
+</tbody>
+</table>
+<hr />
+<h2>Brand Users and Access</h2>
+<p>Brands in Genezio also have users.</p>
+<p>A Genezio account owner can invite team members in two ways:</p>
+<ul>
+<li>to the entire account</li>
+<li>to specific brands inside the account</li>
+</ul>
+<p>This allows organizations to control who can access each brand&#39;s analysis.</p>
+<p>For example:</p>
+<ul>
+<li>growth and SEO leads may need access to all brands</li>
+<li>a client stakeholder may only need access to one brand</li>
+<li>agency team members may be assigned per client brand</li>
+</ul>
+<p>Brand-level access helps keep collaboration organized while limiting visibility to the brands each user should work on.</p>
+<hr />
+<h2>Competitor Brands</h2>
+<p>During analysis, Genezio also detects <strong>competitor brands</strong> that appear in the same AI-generated answers.</p>
+<p>These competitors are identified automatically based on:</p>
+<ul>
+<li>mentions in responses</li>
+<li>recommendations</li>
+<li>comparisons</li>
+</ul>
+<p>Tracking competitors helps you understand how your brand is positioned within the category.</p>
+<hr />
+<h2>Example</h2>
+<p>If the brand being analyzed is:</p>
+<pre><code>HubSpot</code></pre>
+<p>And a user asks an AI assistant:</p>
+<pre><code>What CRM should a startup use?</code></pre>
+<p>The AI might answer:</p>
+<blockquote><p>Popular CRM tools for startups include HubSpot, Pipedrive, and Salesforce.</p></blockquote>
+<p>In this conversation:</p>
+<ul>
+<li><strong>HubSpot</strong> is the analyzed brand</li>
+<li><strong>Pipedrive</strong> and <strong>Salesforce</strong> are detected as competitors</li>
+</ul>
+<p>This information contributes to visibility and competitive analysis metrics.</p>
+<hr />
+<h2>Next Steps</h2>
+<p>To understand how brands are analyzed in different contexts, see:</p>
+<ul>
+<li><a href="./topics.html">Core Concepts -&gt; Topics</a></li>
+<li><a href="./scenarios.html">Core Concepts -&gt; Scenarios</a></li>
+<li><a href="./conversations.html">Core Concepts -&gt; Conversations</a></li>
+</ul>
+<p>These pages explain how Genezio generates the AI conversations used to measure brand visibility.</p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/core-concepts/citations.html
+++ b/new-landing/public/docs/core-concepts/citations.html
@@ -1,0 +1,229 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Citations | Genezio Docs</title>
+  <meta name="description" content="Citations in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="brands.html">Brands</a></li><li><a class="" href="brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="brand-visibility.html">Brand Visibility</a></li><li><a class="" href="users.html">Users</a></li><li><a class="" href="personas.html">Personas</a></li><li><a class="" href="topics.html">Topics</a></li><li><a class="" href="scenarios.html">Scenarios</a></li><li><a class="" href="topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="conversations.html">Conversations</a></li><li><a class="" href="query-fanouts.html">Query Fanouts</a></li><li><a class="active" href="citations.html">Citations</a></li><li><a class="" href="perceptions.html">Perceptions</a></li><li><a class="" href="competitors.html">Competitors</a></li><li><a class="" href="knowledge-base.html">Knowledge Base</a></li><li><a class="" href="products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Citations</h1>
+<p>In Genezio, <strong>citations</strong> represent the external webpages that an AI system references when generating an answer. In many AI interfaces these are also referred to as <strong>sources</strong>.</p>
+<p>When AI assistants such as ChatGPT, Claude, Gemini, Perplexity, or Google AI Overview produce responses, they often rely on information retrieved from the web. Some systems explicitly show these references as links or numbered sources. Genezio captures and analyzes these references as <strong>citations</strong>.</p>
+<p>Citations help explain:</p>
+<ul>
+<li>where the information in the answer came from</li>
+<li>which websites influence AI-generated responses</li>
+<li>why certain brands appear in answers</li>
+</ul>
+<hr />
+<h2>What a Citation Represents</h2>
+<p>A citation corresponds to a <strong>specific webpage or document</strong> that influenced an AI-generated answer.</p>
+<p>Examples of common citation types include:</p>
+<ul>
+<li>a product or service page</li>
+<li>a comparison article</li>
+<li>a review site</li>
+<li>a documentation page</li>
+<li>a regulatory or research source</li>
+</ul>
+<p>Each referenced URL becomes a <strong>citation</strong> recorded by Genezio.</p>
+<hr />
+<h2>Citations vs Sources</h2>
+<p>Different AI systems use different terminology. Some interfaces display links as <strong>citations</strong>, while others label them as <strong>sources</strong>.</p>
+<p>In Genezio, both terms refer to the same concept: the webpages that contributed information used by the AI system when generating its answer.</p>
+<hr />
+<h2>Domain Grouping</h2>
+<p>A single website may appear in many conversations across different pages. To simplify analysis, Genezio can <strong>group citations by domain</strong>.</p>
+<p>For example, instead of analyzing dozens of individual URLs from the same website, Genezio can aggregate them under a single domain such as:</p>
+<pre><code>example.com</code></pre>
+<p>Domain grouping helps users quickly identify:</p>
+<ul>
+<li>which websites influence AI answers the most</li>
+<li>which publications dominate a topic</li>
+<li>which domains frequently mention competitors</li>
+</ul>
+<p>This makes it easier to analyze the overall <strong>influence of a website</strong>, rather than focusing only on individual pages.</p>
+<hr />
+<h2>Citation Attributes</h2>
+<p>Each citation in Genezio includes several attributes that help analyze its role in AI responses.</p>
+<h3>URL</h3>
+<p>The exact webpage referenced by the AI system.</p>
+<hr />
+<h3>Occurrences</h3>
+<p>The number of conversations in which the citation appears.</p>
+<p>Higher occurrence counts often indicate that a source strongly influences AI answers for that topic.</p>
+<hr />
+<h3>Sentiment</h3>
+<p>Genezio analyzes how the brand is described in the context of the citation.</p>
+<p>Possible classifications include:</p>
+<ul>
+<li>Positive</li>
+<li>Neutral</li>
+<li>Negative</li>
+</ul>
+<p>This helps identify whether sources portray a brand favorably or critically.</p>
+<hr />
+<h2>Automatic Citation Classification</h2>
+<p>Genezio automatically <strong>classifies citations</strong> to help users understand the type of source influencing AI responses.</p>
+<p>These classifications appear directly in the citation interface.</p>
+<h3>Source Ownership</h3>
+<p>Genezio determines whether a citation belongs to the analyzed brand, a competitor, or a neutral third party.</p>
+<p>Examples include:</p>
+<ul>
+<li>First Party</li>
+<li>Competitor Owned</li>
+<li>Third-Party Editorial</li>
+</ul>
+<hr />
+<h3>Source Category</h3>
+<p>Genezio identifies the type of content where the citation appears.</p>
+<p>Examples include:</p>
+<ul>
+<li>Blog / Article</li>
+<li>Review (Editorial)</li>
+<li>Review (User-Generated)</li>
+<li>Comparison / Vs Page</li>
+<li>Listicle / Best-Of</li>
+<li>News Article</li>
+<li>Press Release</li>
+<li>Documentation / Knowledge Base</li>
+<li>Case Study</li>
+<li>Research Paper / Report</li>
+</ul>
+<hr />
+<h3>Website Type</h3>
+<p>The broader category of the website hosting the content.</p>
+<p>Examples include:</p>
+<ul>
+<li>Industry / Trade Publication</li>
+<li>Government / Regulatory</li>
+<li>Academic / Research</li>
+<li>Aggregator / Marketplace</li>
+<li>Social / UGC Platform</li>
+<li>Other</li>
+</ul>
+<hr />
+<h2>Auto-Clarification of Citations</h2>
+<p>Genezio automatically <strong>enriches and clarifies citations</strong> by analyzing each source and assigning these classifications.</p>
+<p>This process helps users quickly understand:</p>
+<ul>
+<li>whether a citation belongs to a competitor</li>
+<li>whether the source is editorial, a review, or a product page</li>
+<li>whether the source is first-party or third-party</li>
+</ul>
+<p>Instead of manually inspecting every link, users can immediately see the role and type of each source directly in the citation list.</p>
+<hr />
+<h2>Citations in the Conversation View</h2>
+<p>Citations can be inspected in the <strong>conversation detail view</strong>.</p>
+<p>In this view, Genezio displays:</p>
+<ul>
+<li>the AI response</li>
+<li>the citations (sources) referenced by the AI system</li>
+<li>the associated follow-up searches (called query fanouts)</li>
+<li>detected brand mentions</li>
+</ul>
+<p>This transparency allows users to see exactly <strong>which sources contributed to a specific AI answer</strong>.</p>
+<hr />
+<h2>Citations and Perceptions</h2>
+<p>Citations are not just a list of links — they are directly connected to what AI systems actually say about your brand. From any citation, you can see the <strong>perceptions derived from that source</strong>: the claims and impressions an answer engine formed using information from that page.</p>
+<p>This connection works in both directions. You can also view perceptions <strong>by citation domain</strong>, making it easy to see which websites are shaping how your brand is described across many answers. To learn more about how Genezio captures and analyzes what AI systems say, see <a href="../core-concepts/perceptions.html">Core Concepts -&gt; Perceptions</a>.</p>
+<h3>Cited vs Mentioned Sources</h3>
+<p>Not every source plays the same role in an answer. Genezio distinguishes between:</p>
+<ul>
+<li><strong>Cited</strong> sources — pages the answer engine explicitly cited as references</li>
+<li><strong>Mentioned</strong> sources — pages that were merely referenced or surfaced without being explicitly cited</li>
+</ul>
+<p>This distinction helps you focus on the sources that the AI system is genuinely relying on, versus those that simply came up along the way.</p>
+<h3>Working With Citations</h3>
+<p>The citation interface includes several capabilities that make sources easier to analyze:</p>
+<ul>
+<li><strong>Group sources by domain</strong> — collapse many individual URLs from the same website into a single domain view, so you can judge the overall influence of a site rather than each page.</li>
+<li><strong>Filter by ownership</strong> — narrow the list to <strong>&quot;My citations&quot;</strong> (first-party sources you own) versus third-party sources, to quickly separate your own content from everything else.</li>
+<li><strong>&quot;Competitors mentioned&quot; chip</strong> — citation rows surface a chip indicating when competitors are mentioned in that source, so you can spot competitive exposure at a glance.</li>
+</ul>
+<hr />
+<h2>Why Citation Analysis Matters</h2>
+<p>Citation analysis helps organizations understand the <strong>information landscape influencing AI systems</strong>.</p>
+<p>By identifying which sources appear most frequently, teams can:</p>
+<ul>
+<li>understand which websites shape AI responses</li>
+<li>identify influential publications in their category</li>
+<li>detect sources mentioning competitors</li>
+<li>discover opportunities to improve visibility</li>
+</ul>
+<hr />
+<h2>Next Steps</h2>
+<p>To understand how citations interact with other extracted signals, see:</p>
+<ul>
+<li><a href="./perceptions.html">Core Concepts -&gt; Perceptions</a></li>
+<li><a href="../insights/ai-visibility-score.html">Insights -&gt; Visibility Score</a></li>
+<li><a href="../insights/share-of-voice.html">Insights -&gt; Share of Voice</a></li>
+</ul>
+<p>These pages explain how Genezio converts AI responses into measurable visibility insights.</p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/core-concepts/competitors.html
+++ b/new-landing/public/docs/core-concepts/competitors.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Competitors | Genezio Docs</title>
+  <meta name="description" content="Competitors in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="brands.html">Brands</a></li><li><a class="" href="brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="brand-visibility.html">Brand Visibility</a></li><li><a class="" href="users.html">Users</a></li><li><a class="" href="personas.html">Personas</a></li><li><a class="" href="topics.html">Topics</a></li><li><a class="" href="scenarios.html">Scenarios</a></li><li><a class="" href="topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="conversations.html">Conversations</a></li><li><a class="" href="query-fanouts.html">Query Fanouts</a></li><li><a class="" href="citations.html">Citations</a></li><li><a class="" href="perceptions.html">Perceptions</a></li><li><a class="active" href="competitors.html">Competitors</a></li><li><a class="" href="knowledge-base.html">Knowledge Base</a></li><li><a class="" href="products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Competitors</h1>
+<p>In Genezio, <strong>competitors</strong> are brands that appear in AI-generated answers alongside the brand being analyzed.</p>
+<p>When AI systems respond to questions, they frequently recommend or compare multiple products or services within the same category. Genezio automatically detects these brands and classifies them as <strong>competitors</strong>.</p>
+<p>Competitors are tracked at the <strong>brand level</strong>. Each brand you create in Genezio has its own competitor landscape. For multi-product companies, this is why product modeling matters: if each product has distinct competitors and its own brand presence, separate brands per product gives the cleanest view. If the parent brand is strong but the products don&#39;t have independent brand recognition, one brand with <a href="products.html">Products</a> is the better fit. See <a href="brands.html#multi-product-companies">Brands -&gt; Multi-Product Companies</a> for the full decision.</p>
+<p>Tracking competitors helps organizations understand how their brand is positioned relative to alternatives in AI-generated answers.</p>
+<hr />
+<h2>Automatic Competitor Detection</h2>
+<p>Genezio automatically identifies competitor brands during conversation analysis.</p>
+<p>Competitors are detected when:</p>
+<ul>
+<li>an AI response recommends multiple products</li>
+<li>brands are mentioned in the same answer</li>
+<li>products are compared against each other</li>
+<li>sources cited by the AI reference competing brands</li>
+</ul>
+<p>For example, if a conversation asks about tools for managing customer relationships, the AI system might mention several products in the same answer. These brands are automatically extracted and tracked as competitors.</p>
+<p>By aggregating these mentions across many conversations, Genezio builds a <strong>competitor landscape</strong> for each topic.</p>
+<hr />
+<h2>Competitors Across Topics</h2>
+<p>Competitors can vary depending on the topic being analyzed.</p>
+<p>For example, a brand may compete with different products depending on the user&#39;s intent or scenario.</p>
+<p>Example:</p>
+<ul>
+<li>Topic: CRM for startups</li>
+<li>Topic: marketing automation platforms</li>
+</ul>
+<p>The set of competitors appearing in AI answers may differ between these topics.</p>
+<p>This helps organizations understand how AI systems interpret the competitive landscape for different problems.</p>
+<hr />
+<h2>Managing Competitors</h2>
+<p>While competitor detection is automatic, users can adjust the competitor list to better reflect their market.</p>
+<p>Genezio allows users to:</p>
+<h3>Promote Competitors</h3>
+<p>If a relevant competitor is detected but not strongly represented, users can <strong>promote</strong> the brand so it is treated as a primary competitor in analysis.</p>
+<hr />
+<h3>Demote Competitors</h3>
+<p>Sometimes AI systems mention brands that are not true competitors.</p>
+<p>Users can <strong>demote</strong> these brands so they are treated as less relevant in competitive analysis.</p>
+<hr />
+<h3>Merge Competitors</h3>
+<p>Different names or variations may refer to the same brand.</p>
+<p>For example, a brand might appear with slightly different naming variations across responses.</p>
+<p>Genezio allows users to <strong>merge competitor entries</strong> so that all mentions are consolidated under a single brand.</p>
+<p>This keeps analysis consistent across conversations.</p>
+<hr />
+<h3>Attach Competitors to Your Brand</h3>
+<p>In some cases, a detected competitor may actually belong to the analyzed brand.</p>
+<p>Examples include:</p>
+<ul>
+<li>sub-brands</li>
+<li>acquired companies</li>
+<li>product lines belonging to the same organization</li>
+</ul>
+<p>Users can <strong>attach these entities to their brand</strong>, ensuring they are treated as part of the same brand rather than as a competitor.</p>
+<hr />
+<h2>Competitors in Analysis</h2>
+<p>Once detected, competitors are used throughout the platform to generate insights.</p>
+<p>Competitor data helps power metrics such as:</p>
+<ul>
+<li><strong>AI Recommendations and Visibility comparisons</strong></li>
+<li><strong>Share of Voice</strong></li>
+<li><strong>Competitive positioning in AI answers</strong></li>
+<li><strong>topic-level brand presence</strong></li>
+</ul>
+<p>This allows teams to see not only how often their brand appears, but also <strong>which brands dominate the conversation</strong>.</p>
+<hr />
+<h2>Competitors in the Interface</h2>
+<p>Competitors appear across several parts of the Genezio interface, including:</p>
+<ul>
+<li>topic analysis views</li>
+<li>visibility comparisons</li>
+<li>conversation details</li>
+<li>citation analysis</li>
+</ul>
+<p>Users can inspect how competitors appear in specific conversations and which sources reference them.</p>
+<hr />
+<h2>Why Competitor Analysis Matters</h2>
+<p>AI assistants increasingly shape how users discover and compare products.</p>
+<p>Understanding which brands appear alongside yours helps answer questions such as:</p>
+<ul>
+<li>Which competitors does AI recommend most often?</li>
+<li>Which competitors dominate certain topics?</li>
+<li>Which sources mention competitors but not your brand?</li>
+</ul>
+<p>These insights help organizations identify opportunities to improve their AI Recommendations and Visibility.</p>
+<hr />
+<h2>Next Steps</h2>
+<p>To see how competitor data contributes to visibility metrics, continue with:</p>
+<ul>
+<li><a href="../insights/ai-visibility-score.html">Insights -&gt; Visibility Score</a></li>
+<li><a href="../insights/share-of-voice.html">Insights -&gt; Share of Voice</a></li>
+</ul>
+<p>These pages explain how Genezio converts conversation data into measurable AI visibility insights.</p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/core-concepts/conversations.html
+++ b/new-landing/public/docs/core-concepts/conversations.html
@@ -1,0 +1,183 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Conversations | Genezio Docs</title>
+  <meta name="description" content="Conversations in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="brands.html">Brands</a></li><li><a class="" href="brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="brand-visibility.html">Brand Visibility</a></li><li><a class="" href="users.html">Users</a></li><li><a class="" href="personas.html">Personas</a></li><li><a class="" href="topics.html">Topics</a></li><li><a class="" href="scenarios.html">Scenarios</a></li><li><a class="" href="topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="active" href="conversations.html">Conversations</a></li><li><a class="" href="query-fanouts.html">Query Fanouts</a></li><li><a class="" href="citations.html">Citations</a></li><li><a class="" href="perceptions.html">Perceptions</a></li><li><a class="" href="competitors.html">Competitors</a></li><li><a class="" href="knowledge-base.html">Knowledge Base</a></li><li><a class="" href="products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Conversations</h1>
+<p>In Genezio, a <strong>conversation</strong> represents a single execution of a scenario against a specific AI system.</p>
+<p>Conversations are the events where Genezio interacts with an answer engine and records the results used for analysis.</p>
+<p>Each conversation is therefore an <strong>instance of a scenario</strong> executed with a particular answer engine.</p>
+<hr />
+<h2>Scenario -&gt; Conversation</h2>
+<p>The relationship between scenarios and conversations is straightforward.</p>
+<p>A <strong>scenario</strong> defines the situation and goal of the persona.</p>
+<p>A <strong>conversation</strong> occurs when Genezio executes that scenario with an AI system.</p>
+<p>For example:</p>
+<ul>
+<li>Scenario: &quot;A startup founder looking for a CRM to manage early leads&quot;</li>
+<li>answer engine: ChatGPT</li>
+</ul>
+<p>Running this scenario with ChatGPT creates <strong>one conversation</strong>.</p>
+<p>If the same scenario is executed with multiple AI systems, multiple conversations are created.</p>
+<p>Example:</p>
+<ul>
+<li>Scenario: CRM for startups scenario | Answer Engine: ChatGPT | Conversation: Conversation A</li>
+<li>Scenario: CRM for startups scenario | Answer Engine: Claude | Conversation: Conversation B</li>
+<li>Scenario: CRM for startups scenario | Answer Engine: Gemini | Conversation: Conversation C</li>
+</ul>
+<p>Each of these conversations may produce different responses, citations, and brand mentions.</p>
+<hr />
+<h2>Single-Turn vs Multi-Step Conversations</h2>
+<p>The structure of a conversation depends on the <strong>Genezio Agent type</strong>.</p>
+<h3>Prompter Agent Conversations</h3>
+<p>For <strong>Prompter Agent topics</strong>, the conversation consists of a <strong>single message</strong>.</p>
+<p>The scenario itself becomes the prompt and is sent <strong>word-for-word</strong> to the AI system.</p>
+<p>Example prompt:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>What CRM should a startup use?</strong></em></p></blockquote>
+<p>The AI response is captured and analyzed.</p>
+<hr />
+<h3>Multi-Step Conversations</h3>
+<p>For <strong>Recommender Agent, Introspector Agent, and Comparer Agent topics</strong>, conversations are <strong>multi-step</strong>.</p>
+<p>In these cases:</p>
+<ol>
+<li>The scenario defines the initial situation.</li>
+<li>Genezio generates prompts dynamically.</li>
+<li>The conversation may include several back-and-forth turns.</li>
+</ol>
+<p>These interactions simulate how a real user might explore a topic with an AI assistant.</p>
+<hr />
+<h2>Conversations and Answer Engines</h2>
+<p>Genezio runs conversations across multiple answer engines.</p>
+<p>Examples include:</p>
+<ul>
+<li>ChatGPT</li>
+<li>Claude</li>
+<li>Gemini</li>
+<li>Perplexity</li>
+<li>Google AI Overview</li>
+</ul>
+<p>Running scenarios across different AI systems allows Genezio to measure how brand visibility varies between platforms.</p>
+<hr />
+<h2>Special Case: Google AI Overview</h2>
+<p>Google <strong>AI Overview</strong> behaves differently from conversational AI assistants.</p>
+<p>Instead of interacting with a conversational prompt, AI Overview is triggered by something closer to a <strong>web search query</strong>.</p>
+<p>Because of this difference:</p>
+<ul>
+<li>Genezio converts prompts into <strong>search-style queries</strong> when interacting with AI Overview.</li>
+<li>These queries resemble what a user might type into a Google search box.</li>
+</ul>
+<p>Example:</p>
+<p>Conversation prompt:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>What CRM should a startup use?</strong></em></p></blockquote>
+<p>AI Overview query:</p>
+<blockquote class="query-fanout"><p><strong>Query fanout:</strong> <em><strong>best CRM for startups</strong></em></p></blockquote>
+<p>Genezio generates these queries automatically.</p>
+<p>However, users can <strong>override the generated query</strong> if they want to test a specific search formulation.</p>
+<hr />
+<h2>Conversation Data</h2>
+<p>Each conversation produces a structured set of data that Genezio analyzes.</p>
+<p>This includes:</p>
+<ul>
+<li>the prompts sent to the AI</li>
+<li>the responses generated by the model</li>
+<li>brands mentioned in the response</li>
+<li>sources cited</li>
+<li>follow-up searches (called query fanouts) explored by the system</li>
+</ul>
+<p>This data forms the foundation for metrics such as <strong>AI Recommendations</strong>, <strong>AI Visibility</strong>, <strong>share of voice</strong>, and <strong>competitive analysis</strong>.</p>
+<hr />
+<h2>Conversation Detail View</h2>
+<p>Genezio provides a <strong>conversation detail view</strong> where users can inspect the results of a specific conversation.</p>
+<p>This view allows you to see:</p>
+<ul>
+<li>the full conversation between Genezio and the AI system</li>
+<li>the prompts sent during each turn</li>
+<li>the responses generated by the model</li>
+<li>extracted <strong>query fanouts</strong></li>
+<li>detected <strong>citations</strong></li>
+<li>mentioned <strong>brands and competitors</strong></li>
+</ul>
+<p>This level of transparency helps teams understand exactly <strong>why a brand appeared-or did not appear-in an AI response</strong>.</p>
+<hr />
+<h2>Why Conversations Matter</h2>
+<p>Conversations are the core unit of analysis in Genezio.</p>
+<p>Every visibility metric, insight, and competitor analysis is derived from the results of many conversations executed across topics, personas, and AI systems.</p>
+<p>By analyzing these interactions at scale, Genezio provides a measurable view of how AI systems represent brands.</p>
+<hr />
+<h2>Next Steps</h2>
+<p>To understand how information extracted from conversations is structured and analyzed, see:</p>
+<ul>
+<li><a href="./citations.html">Core Concepts -&gt; Citations</a></li>
+<li><a href="./perceptions.html">Core Concepts -&gt; Perceptions</a></li>
+<li><a href="../insights/ai-visibility-score.html">Insights -&gt; Visibility Score</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/core-concepts/knowledge-base.html
+++ b/new-landing/public/docs/core-concepts/knowledge-base.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Knowledge Base | Genezio Docs</title>
+  <meta name="description" content="Knowledge Base in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="brands.html">Brands</a></li><li><a class="" href="brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="brand-visibility.html">Brand Visibility</a></li><li><a class="" href="users.html">Users</a></li><li><a class="" href="personas.html">Personas</a></li><li><a class="" href="topics.html">Topics</a></li><li><a class="" href="scenarios.html">Scenarios</a></li><li><a class="" href="topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="conversations.html">Conversations</a></li><li><a class="" href="query-fanouts.html">Query Fanouts</a></li><li><a class="" href="citations.html">Citations</a></li><li><a class="" href="perceptions.html">Perceptions</a></li><li><a class="" href="competitors.html">Competitors</a></li><li><a class="active" href="knowledge-base.html">Knowledge Base</a></li><li><a class="" href="products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Knowledge Base</h1>
+<p>The <strong>Knowledge Base</strong> is your brand&#39;s source of truth inside Genezio.</p>
+<p>It&#39;s a corpus of documents, pages, and notes you maintain — the things you&#39;d point to if someone asked, &quot;what&#39;s actually true about your brand?&quot; The platform uses it to check what answer engines are saying about you against what your own materials say.</p>
+<hr />
+<h2>Why a Knowledge Base Exists</h2>
+<p>Answer engines make claims about brands constantly. Some are accurate; some are outdated; some are flat-out wrong.</p>
+<p>Until now, telling the difference required a human to read each perception and check it against an internal source. The Knowledge Base automates that comparison. You provide the truth once, and the platform uses it as the reference every time a perception about your brand gets extracted from an answer engine conversation.</p>
+<p>This is the foundation for an <strong>accuracy audit loop</strong>:</p>
+<ul>
+<li>the platform observes what answer engines say about you</li>
+<li>the Knowledge Base says what&#39;s actually true</li>
+<li>the two get compared, and you see where they agree and where they don&#39;t</li>
+</ul>
+<hr />
+<h2>Where to Set It Up</h2>
+<p>The Knowledge Base lives under <strong>Brand Settings → Knowledge Base</strong>.</p>
+<p>Setting it up is a one-time configuration step per brand. Once it&#39;s in place, it works in the background — every new perception extracted from conversations is checked against it automatically.</p>
+<h3>You Start With One Already</h3>
+<p>You don&#39;t begin from an empty Knowledge Base.</p>
+<p>When a brand is created, Genezio automatically crawls the <strong>brand&#39;s website</strong> and adds it as the first Knowledge Base item. That means grounded-perception checks work from day one, using your public site as the initial source of truth — even if you&#39;ve done no other setup.</p>
+<p>From there, you build the Knowledge Base out by adding the documents, URLs, and free-text snippets that your website doesn&#39;t cover.</p>
+<hr />
+<h2>What You Can Put In It</h2>
+<p>The Knowledge Base accepts three kinds of input, so you can use whatever format your truth lives in today:</p>
+<ul>
+<li><strong>Documents</strong> — upload datasheets, FAQs, positioning docs, internal one-pagers, or any other file that captures brand truth</li>
+<li><strong>URLs</strong> — point at pages that already represent your official messaging (your product pages, your about page, your pricing page, partner pages)</li>
+<li><strong>Free-text snippets</strong> — paste in facts, definitions, or correction notes that don&#39;t live in a document yet (&quot;our pricing starts at $X&quot;, &quot;we do not offer a free tier&quot;, &quot;our HQ is in Berlin, not San Francisco&quot;)</li>
+</ul>
+<p>Mix and match. A typical Knowledge Base for a mature brand has a handful of authoritative documents, links to a few canonical pages, and a growing list of free-text corrections captured over time.</p>
+<hr />
+<h2>What to Put In It</h2>
+<p>Think about the claims an answer engine would need to get right when describing your brand:</p>
+<ul>
+<li><strong>Products and capabilities</strong> — what you sell, what each product actually does</li>
+<li><strong>Pricing and plans</strong> — current tiers, what&#39;s included, what isn&#39;t</li>
+<li><strong>Target audience and use cases</strong> — who you&#39;re for and who you&#39;re not for</li>
+<li><strong>Competitive differentiators</strong> — the messaging that distinguishes you</li>
+<li><strong>Facts that get mistaken</strong> — the things answer engines have already gotten wrong about you (a great signal: anything you&#39;ve corrected in a sales call belongs here)</li>
+<li><strong>Official statements and brand guidelines</strong> — positioning documents, key messaging, taglines, do-not-say lists</li>
+</ul>
+<p>Quality matters more than volume. A small, accurate, current Knowledge Base is more useful than a large, stale one.</p>
+<hr />
+<h2>How It&#39;s Used</h2>
+<p>Once a Knowledge Base is in place, it powers two things in the platform today:</p>
+<h3>Grounded Perceptions</h3>
+<p>Every perception extracted from an answer engine conversation gets checked against your Knowledge Base. Perceptions that can be verified get a <strong>grounded</strong> badge with one of three states:</p>
+<ul>
+<li><strong>Grounded-correct</strong> — the perception matches what your Knowledge Base says</li>
+<li><strong>Grounded-incorrect</strong> — the perception contradicts what your Knowledge Base says</li>
+<li><strong>Not grounded</strong> — the perception couldn&#39;t be verified either way against your Knowledge Base</li>
+</ul>
+<p>This is the accuracy audit, made visible. See <a href="perceptions.html">Perceptions</a> for how grounded perceptions appear in the platform.</p>
+<h3>Reporting and Insights</h3>
+<p>Grounded perceptions flow into the platform&#39;s reporting. You can see the proportion of perceptions about your brand that are correct, incorrect, or unverifiable — and dig into the specific ones that are getting it wrong, so you can fix the source (your website, your docs, or your Knowledge Base itself).</p>
+<hr />
+<h2>Strength of the Knowledge Base</h2>
+<p>Because every brand starts with its website crawled in, the grounded layer is active from day one. But the <strong>strength</strong> of the signal depends on how much truth your Knowledge Base actually covers.</p>
+<p>If your website is detailed and current, the initial crawl alone delivers a lot of value. If it&#39;s sparse, marketing-heavy, or doesn&#39;t include pricing, specifications, or positioning detail, the platform won&#39;t be able to verify as many perceptions — and you&#39;ll see more &quot;not grounded&quot; badges than you&#39;d like.</p>
+<p>That&#39;s the nudge to extend the Knowledge Base: add the documents, URLs, and snippets that fill the gaps your website leaves.</p>
+<hr />
+<h2>Maintaining the Knowledge Base</h2>
+<p>The Knowledge Base is a living asset. Treat it like a brand book that gets edited:</p>
+<ul>
+<li><strong>Update it when your brand changes</strong> — new product, new pricing, new positioning</li>
+<li><strong>Add to it when you spot an incorrect perception</strong> — if answer engines keep saying something untrue, document the correction in the Knowledge Base so the platform can flag future occurrences</li>
+<li><strong>Prune it when documents go stale</strong> — outdated truth is worse than no truth</li>
+</ul>
+<p>The more current and accurate the Knowledge Base, the more trustworthy the grounded signal becomes.</p>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="perceptions.html">Perceptions</a></li>
+<li><a href="brands.html">Brands</a></li>
+<li><a href="competitors.html">Competitors</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/core-concepts/perceptions.html
+++ b/new-landing/public/docs/core-concepts/perceptions.html
@@ -1,0 +1,206 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Perceptions | Genezio Docs</title>
+  <meta name="description" content="Perceptions in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="brands.html">Brands</a></li><li><a class="" href="brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="brand-visibility.html">Brand Visibility</a></li><li><a class="" href="users.html">Users</a></li><li><a class="" href="personas.html">Personas</a></li><li><a class="" href="topics.html">Topics</a></li><li><a class="" href="scenarios.html">Scenarios</a></li><li><a class="" href="topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="conversations.html">Conversations</a></li><li><a class="" href="query-fanouts.html">Query Fanouts</a></li><li><a class="" href="citations.html">Citations</a></li><li><a class="active" href="perceptions.html">Perceptions</a></li><li><a class="" href="competitors.html">Competitors</a></li><li><a class="" href="knowledge-base.html">Knowledge Base</a></li><li><a class="" href="products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Perceptions</h1>
+<p>In Genezio, a <strong>perception</strong> is an individual claim extracted from an AI-generated answer about a brand, product, or category.</p>
+<p>When an AI system responds to a question, the response usually contains several claims. Genezio breaks these responses down into smaller units called <strong>perceptions</strong> so each claim can be evaluated on its own — because together, these claims are how answer engines <em>perceive</em> and describe your brand to buyers.</p>
+<blockquote><p><strong>Note:</strong> Perceptions were previously called <strong>Statements</strong>. The concept is the same — the name now better reflects that these claims represent how AI systems perceive your brand.</p></blockquote>
+<p>Perceptions help answer questions such as:</p>
+<ul>
+<li>What exactly did the AI say about a brand?</li>
+<li>Is the claim correct or incorrect?</li>
+<li>Which source supports the claim?</li>
+<li>Which competitors are mentioned in the same context?</li>
+</ul>
+<p>By converting AI responses into perceptions, Genezio makes it possible to verify whether answer engines are telling the truth about your brand — and to track the narrative they associate with it.</p>
+<hr />
+<h2>Why Perceptions Are Important</h2>
+<p>AI responses are often long paragraphs that combine multiple ideas. Without breaking them apart, it is difficult to tell which claims are accurate and which are not.</p>
+<p>For example, an AI assistant might produce an answer like:</p>
+<blockquote><p>Popular CRM tools for startups include HubSpot, Pipedrive, and Zoho CRM. HubSpot is known for its strong marketing automation features, while Pipedrive focuses on simple sales pipeline management.</p></blockquote>
+<p>This response actually contains several distinct claims. Genezio extracts them as separate perceptions such as:</p>
+<ul>
+<li>HubSpot is a CRM tool used by startups</li>
+<li>Pipedrive is a CRM tool used by startups</li>
+<li>Zoho CRM is a CRM tool used by startups</li>
+<li>HubSpot is known for marketing automation</li>
+<li>Pipedrive focuses on pipeline management</li>
+</ul>
+<p>Each of these becomes an individual <strong>perception</strong> that can be evaluated for accuracy against what your brand actually does.</p>
+<hr />
+<h2>Perception Accuracy</h2>
+<p>The most important thing about a perception is whether it is <strong>correct or incorrect</strong>.</p>
+<p>Answer engines make claims about brands all the time — and those claims shape how buyers perceive you. Some claims are accurate. Others are outdated, misleading, or simply wrong.</p>
+<p>Examples:</p>
+<ul>
+<li><em>&quot;Zara is a fast fashion brand&quot;</em> → <strong>Correct</strong></li>
+<li><em>&quot;Gucci is a fast fashion brand&quot;</em> → <strong>Incorrect</strong></li>
+<li><em>&quot;HubSpot offers a free CRM tier&quot;</em> → <strong>Correct</strong></li>
+<li><em>&quot;Pipedrive includes built-in marketing automation&quot;</em> → <strong>Incorrect</strong></li>
+</ul>
+<p>When an answer engine makes an incorrect claim about your brand, it can mislead buyers and cost you recommendations. When it makes a correct claim, it reinforces your positioning.</p>
+<h3>How Accuracy Is Determined</h3>
+<p>To evaluate whether a perception is correct or incorrect, Genezio compares it against your <strong><a href="knowledge-base.html">Knowledge Base</a></strong> — a brand-specific source of truth you set up once in <strong>Brand Settings</strong>.</p>
+<p>The Knowledge Base typically includes:</p>
+<ul>
+<li>product descriptions and capabilities</li>
+<li>pricing and plans</li>
+<li>target audience and use cases</li>
+<li>competitive differentiators</li>
+<li>any other official brand guidelines</li>
+</ul>
+<p>By comparing AI-generated claims against your Knowledge Base, Genezio can flag perceptions that misrepresent your brand — giving you a clear view of where answer engines are getting it right and where they are getting it wrong.</p>
+<h3>Grounded Perceptions</h3>
+<p>When a Knowledge Base is in place, every perception extracted from a conversation gets a <strong>grounded</strong> badge showing whether it could be verified — and how. The badge has three states:</p>
+<ul>
+<li><strong>Grounded-correct</strong> — the perception matches what your Knowledge Base says is true</li>
+<li><strong>Grounded-incorrect</strong> — the perception contradicts your Knowledge Base</li>
+<li><strong>Not grounded</strong> — the perception couldn&#39;t be verified against your Knowledge Base either way</li>
+</ul>
+<p>A tooltip on the badge explains what each state means in context.</p>
+<p>The badge turns a list of perceptions into a triage queue: scan the grounded-incorrect ones first (these are answer engines actively misrepresenting your brand), then work through the not-grounded ones (gaps in either your Knowledge Base or in how your messaging is documented publicly). Grounded-correct perceptions are the wins — proof that the narrative answer engines have about you matches the truth.</p>
+<p>Every brand gets a Knowledge Base from day one (the brand&#39;s website is crawled in automatically when the brand is created), so the grounded layer is active immediately. How much it can verify depends on how much truth your Knowledge Base covers — see <a href="knowledge-base.html">Knowledge Base</a> for what to add.</p>
+<hr />
+<h2>Perceptions and Their Sources</h2>
+<p>Every perception can be traced back to the <strong>sources</strong> that produced it. This is one of the most useful things you can do with a perception: see <em>why</em> the AI said what it said.</p>
+<p>When you open a perception, Genezio shows the <strong>citation paragraphs</strong> (the exact passages from cited webpages) that back the claim, with the <strong>matching text highlighted</strong>. That lets you jump from &quot;the AI says we&#39;re hard to set up&quot; straight to the third-party page that planted that idea — so you know exactly where to focus a correction or outreach effort.</p>
+<p>The link works in both directions:</p>
+<ul>
+<li><strong>From a perception</strong> → see the sources (citation paragraphs) that support it, with matched text highlighted.</li>
+<li><strong>From a citation</strong> → see all the perceptions derived from that source.</li>
+<li><strong>By citation domain</strong> → view the perceptions associated with a specific domain, so you can tell which websites are shaping your narrative.</li>
+</ul>
+<p>Genezio also distinguishes between sources that are <strong>explicitly cited</strong> by the answer engine and brands or pages that are merely <strong>mentioned</strong>, so you can separate the references the model actually leaned on from passing mentions.</p>
+<p>See <a href="citations.html">Citations</a> for how sources are captured and classified.</p>
+<hr />
+<h2>Other Perception Attributes</h2>
+<h3>Text</h3>
+<p>The actual claim made in the AI response.</p>
+<p>Example:</p>
+<pre><code>HubSpot is known for strong marketing automation features.</code></pre>
+<hr />
+<h3>Brand References</h3>
+<p>The brands mentioned in the perception.</p>
+<p>A single perception may reference one or multiple brands.</p>
+<p>Example:</p>
+<pre><code>HubSpot and Salesforce are widely used CRM platforms.</code></pre>
+<hr />
+<h3>Supporting Citations</h3>
+<p>Perceptions are linked to one or more <strong>citations (sources)</strong> that the AI system used when generating the claim.</p>
+<p>This makes it possible to trace a perception back to the webpage that influenced it — and understand why the AI made a particular claim.</p>
+<hr />
+<h2>Perceptions Across Conversations</h2>
+<p>Perceptions are extracted from every conversation that Genezio runs with AI systems, and they are generated in your <strong>brand&#39;s own language</strong>, so reports read naturally for local markets.</p>
+<p>By aggregating perceptions across many conversations, Genezio can identify patterns such as:</p>
+<ul>
+<li>recurring claims made about a brand — correct or incorrect</li>
+<li>common inaccuracies that need to be addressed</li>
+<li>frequently mentioned competitors</li>
+<li>differences in how AI systems describe the same brand</li>
+</ul>
+<p>This helps organizations understand the <strong>narrative that AI systems associate with their brand</strong> — and whether that narrative is accurate.</p>
+<hr />
+<h2>Perceptions in the Interface</h2>
+<p>In Genezio, perceptions can be explored in the <strong>conversation detail view</strong> and across aggregated analysis views. Lists of perceptions can be <strong>sorted</strong> to bring the most relevant claims to the top.</p>
+<p>Users can inspect:</p>
+<ul>
+<li>the original AI response</li>
+<li>the extracted perceptions</li>
+<li>the accuracy of each claim</li>
+<li>the associated citations, with the supporting paragraphs highlighted</li>
+<li>the brands mentioned in each claim</li>
+</ul>
+<p>This transparency allows teams to see exactly what AI systems are saying about their brand — and whether it is true.</p>
+<hr />
+<h2>Perceptions and Insights</h2>
+<p>Perceptions form the foundation for several higher-level insights in Genezio.</p>
+<p>They contribute to:</p>
+<ul>
+<li>AI Recommendations — incorrect claims can reduce your recommendation rate</li>
+<li>AI Visibility — inaccurate descriptions affect how often answer engines surface your brand</li>
+<li>Share of Voice — the accuracy of claims shapes competitive positioning</li>
+<li>Competitive positioning — understanding which claims favor you vs. competitors</li>
+<li><a href="../insights/ai-perception-summary.html">AI Perception Summary</a> — the overall, AI-generated narrative of how your brand is perceived</li>
+</ul>
+<p>By structuring AI responses into perceptions and evaluating their accuracy, Genezio transforms unstructured AI answers into data that can be measured, verified, and acted on.</p>
+<hr />
+<h2>Next Steps</h2>
+<p>To understand how perceptions and citations combine to measure brand presence, see:</p>
+<ul>
+<li><a href="../insights/ai-visibility-score.html">Insights -&gt; Visibility Score</a></li>
+<li><a href="../insights/share-of-voice.html">Insights -&gt; Share of Voice</a></li>
+<li><a href="../insights/ai-perception-summary.html">Insights -&gt; AI Perception Summary</a></li>
+</ul>
+<p>These pages explain how Genezio turns conversation data into measurable AI visibility metrics.</p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/core-concepts/personas.html
+++ b/new-landing/public/docs/core-concepts/personas.html
@@ -1,0 +1,232 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Personas | Genezio Docs</title>
+  <meta name="description" content="Personas in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="brands.html">Brands</a></li><li><a class="" href="brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="brand-visibility.html">Brand Visibility</a></li><li><a class="" href="users.html">Users</a></li><li><a class="active" href="personas.html">Personas</a></li><li><a class="" href="topics.html">Topics</a></li><li><a class="" href="scenarios.html">Scenarios</a></li><li><a class="" href="topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="conversations.html">Conversations</a></li><li><a class="" href="query-fanouts.html">Query Fanouts</a></li><li><a class="" href="citations.html">Citations</a></li><li><a class="" href="perceptions.html">Perceptions</a></li><li><a class="" href="competitors.html">Competitors</a></li><li><a class="" href="knowledge-base.html">Knowledge Base</a></li><li><a class="" href="products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Personas</h1>
+<p>In Genezio, a <strong>persona</strong> represents the type of user who might ask questions about a brand when interacting with an AI assistant.</p>
+<p>Personas help simulate realistic conversations by defining <strong>who is asking the questions</strong>, <strong>where they are located</strong>, and <strong>what language they use</strong>.</p>
+<p>Every persona belongs to a specific <strong>brand</strong>, and each <strong>topic</strong> is associated with a persona. This ensures that AI conversations are generated from the perspective of the brand&#39;s real customers.</p>
+<hr />
+<h2>What a Persona Represents</h2>
+<p>A persona describes a typical user or buyer for the brand being analyzed.</p>
+<p>For example, a persona might represent:</p>
+<ul>
+<li>a startup founder looking for CRM software</li>
+<li>a marketing manager searching for automation tools</li>
+<li>a runner researching marathon training shoes</li>
+</ul>
+<p>By modeling the user behind the question, Genezio can generate conversations that more closely resemble real interactions with AI systems.</p>
+<hr />
+<h2>Persona Attributes</h2>
+<p>Each persona includes several attributes that influence how conversations are generated.</p>
+<h3>Brand Association</h3>
+<p>Every persona belongs to a <strong>specific brand</strong>.</p>
+<p>This means the persona represents a typical customer or user of that brand&#39;s products or services.</p>
+<p>Example:</p>
+<ul>
+<li>Brand: HubSpot</li>
+<li>Persona: Startup founder managing sales and marketing</li>
+</ul>
+<hr />
+<h3>Language</h3>
+<p>Each persona speaks a specific <strong>language</strong>.</p>
+<p>This determines the language used when Genezio runs conversations with AI systems.</p>
+<p>Example:</p>
+<ul>
+<li>English</li>
+<li>Spanish</li>
+<li>French</li>
+</ul>
+<p>The conversation prompts, responses, and analysis are performed in that language.</p>
+<hr />
+<h3>Location</h3>
+<p>Each persona is also associated with a <strong>country and city</strong>.</p>
+<p>When Genezio runs AI conversations, they are executed <strong>as if the user were located in that specific place</strong>.</p>
+<p>This helps simulate realistic conditions because AI systems may adapt answers based on geographic context.</p>
+<p>For example:</p>
+<ul>
+<li>Country: United States</li>
+<li>City: San Francisco</li>
+</ul>
+<p>or</p>
+<ul>
+<li>Country: Germany</li>
+<li>City: Berlin</li>
+</ul>
+<p>Location can influence recommendations, available products, regulatory context, or regional preferences.</p>
+<hr />
+<h2>Persona Impersonation During Conversations</h2>
+<p>When Genezio interacts with an AI system, it <strong>acts as the defined persona</strong>.</p>
+<p>This means Genezio generates prompts and follow-up questions <strong>as if it were that user</strong>. The system effectively impersonates the persona when talking to the answer engine.</p>
+<p>For example, if the persona represents:</p>
+<ul>
+<li>a startup founder</li>
+<li>located in San Francisco</li>
+<li>speaking English</li>
+</ul>
+<p>then the conversation with the AI assistant is written from that perspective. The questions, tone, and context reflect how that specific user might ask for recommendations or information.</p>
+<p>This approach helps ensure that the responses generated by AI systems reflect realistic user behavior rather than generic test prompts.</p>
+<hr />
+<h2>How Personas Are Used in Genezio</h2>
+<p>Personas influence how topics and scenarios are executed during AI conversations.</p>
+<p>The process works as follows:</p>
+<ol>
+<li>A brand defines one or more personas.</li>
+<li>Each topic is associated with a persona.</li>
+<li>Scenarios are generated based on that topic and persona.</li>
+<li>Genezio runs conversations with the AI system while impersonating the persona.</li>
+<li>The conversation uses the persona&#39;s language and geographic context.</li>
+</ol>
+<p>This approach ensures that conversations reflect <strong>how real users from specific markets might interact with AI systems</strong>.</p>
+<hr />
+<h2>Example</h2>
+<p>Consider a brand that sells CRM software for startups.</p>
+<p>A persona might look like this:</p>
+<ul>
+<li>Persona: Early-stage startup founder</li>
+<li>Language: English</li>
+<li>Country: United States</li>
+<li>City: San Francisco</li>
+</ul>
+<p>A topic associated with this persona might be:</p>
+<pre><code>CRM tools for startups</code></pre>
+<p>When Genezio runs conversations for this topic, the AI system receives prompts that simulate a user in San Francisco asking questions in English about CRM solutions.</p>
+<hr />
+<h2>Example: Different Personas for the Same Brand</h2>
+<p>Personas are especially important when the <strong>same brand serves different types of users</strong>.</p>
+<p>For example, consider a bank that offers debit cards.</p>
+<p>Two personas might interact with AI systems very differently:</p>
+<p><strong>Persona 1 - Teenager (15 years old)</strong></p>
+<ul>
+<li>Goal: get a debit card connected to their parents&#39; account</li>
+<li>Language: informal, simple</li>
+<li>Questions might look like:</li>
+</ul>
+<pre><code>Can I get a debit card if I&#39;m 15?
+Is there a card for teens connected to my parents account?
+Which banks offer debit cards for teenagers?</code></pre>
+<p><strong>Persona 2 - Adult (40 years old)</strong></p>
+<ul>
+<li>Goal: open a new personal bank account</li>
+<li>Language: more direct and financial</li>
+<li>Questions might look like:</li>
+</ul>
+<pre><code>What bank offers the best checking account?
+Which banks have good debit cards and mobile apps?
+What are the fees for opening a new bank account?</code></pre>
+<p>Both personas may interact with the <strong>same brand and similar products</strong>, but the way they ask questions-and therefore how AI systems answer-can be very different.</p>
+<p>Modeling personas allows Genezio to capture these differences and simulate how AI systems respond to different types of users.</p>
+<hr />
+<h2>Creating a Persona From a Document</h2>
+<p>If you already have persona research documented somewhere — a buyer-persona document, an internal customer-research deck, a job description, or anything else that describes who your customers are — you can upload it and Genezio will generate a persona from it automatically.</p>
+<p>This is the fastest path to a usable persona, and it&#39;s the recommended starting point for teams who:</p>
+<ul>
+<li>already maintain persona documents in a research repository or marketing collateral</li>
+<li>have customer-research output from a CRM, customer success tool, or sales discovery process</li>
+<li>want to get started without filling out a multi-field form from scratch</li>
+</ul>
+<h3>How It Works</h3>
+<p>Upload the document on the persona creation screen. Genezio reads it and generates a persona — name, role, country, city, language, and supporting context — based on what&#39;s in the document. The persona is <strong>saved immediately</strong> as a real, usable persona for the brand. You can edit it afterwards like any other persona if anything needs tuning.</p>
+<p>Each upload generates <strong>one persona</strong>. If your document describes several distinct personas, upload it separately for each one (or split the doc).</p>
+<h3>Why This Matters</h3>
+<p>Building good personas is the single biggest blocker to getting meaningful results out of the platform. A weak persona produces weak conversations, which produce weak insights. Starting from a real document — one that already encodes how your team thinks about a customer segment — gets you to a useful persona in one step, instead of asking a non-research team to write something convincing into an empty form.</p>
+<p>For customers who already have persona research, it&#39;s effectively a one-step import.</p>
+<hr />
+<h2>Managing Personas</h2>
+<p>Genezio makes it easy to keep personas organized and portable:</p>
+<ul>
+<li><strong>Export personas</strong> — you can export all of your personas at once, or export a specific persona on its own, which is useful for sharing persona definitions or keeping them alongside other research.</li>
+<li><strong>Summary field</strong> — each persona can carry a <strong>summary</strong> that captures, at a glance, who the persona is and what they care about.</li>
+<li><strong>Consistent country list</strong> — persona creation uses a <strong>consistent country list</strong>, so locations are standardized across every persona. Personas are then generated and used in the persona&#39;s <strong>own language and location</strong>, keeping conversations grounded in the right market.</li>
+</ul>
+<hr />
+<h2>Why Personas Matter</h2>
+<p>Personas allow Genezio to simulate <strong>realistic discovery scenarios</strong>.</p>
+<p>Different users may ask different questions depending on:</p>
+<ul>
+<li>their role</li>
+<li>their goals</li>
+<li>their market</li>
+<li>their language</li>
+</ul>
+<p>By modeling these factors, Genezio can better represent how AI systems respond to real-world users.</p>
+<hr />
+<h2>Next Steps</h2>
+<p>To learn how personas connect to other parts of the analysis, see:</p>
+<ul>
+<li><a href="./topics.html">Core Concepts -&gt; Topics</a></li>
+<li><a href="./scenarios.html">Core Concepts -&gt; Scenarios</a></li>
+<li><a href="./conversations.html">Core Concepts -&gt; Conversations</a></li>
+</ul>
+<p>These pages explain how Genezio uses personas to generate the AI conversations used to measure visibility.</p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/core-concepts/products.html
+++ b/new-landing/public/docs/core-concepts/products.html
@@ -1,0 +1,158 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Products | Genezio Docs</title>
+  <meta name="description" content="Products in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="brands.html">Brands</a></li><li><a class="" href="brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="brand-visibility.html">Brand Visibility</a></li><li><a class="" href="users.html">Users</a></li><li><a class="" href="personas.html">Personas</a></li><li><a class="" href="topics.html">Topics</a></li><li><a class="" href="scenarios.html">Scenarios</a></li><li><a class="" href="topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="conversations.html">Conversations</a></li><li><a class="" href="query-fanouts.html">Query Fanouts</a></li><li><a class="" href="citations.html">Citations</a></li><li><a class="" href="perceptions.html">Perceptions</a></li><li><a class="" href="competitors.html">Competitors</a></li><li><a class="" href="knowledge-base.html">Knowledge Base</a></li><li><a class="active" href="products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Products</h1>
+<p><strong>Products</strong> let you slice a single brand&#39;s data by product line — so a multi-product company can stay as one brand in Genezio and still see how each product is doing individually.</p>
+<p>A product is defined as a <strong>set of topics</strong>. When you create products and pick one from the product picker, every view in Genezio narrows to that product&#39;s topics: dashboards, conversations, insights, citations, share of voice, perceptions, everything.</p>
+<hr />
+<h2>When to Use Products vs. Separate Brands</h2>
+<p>Genezio supports two ways to model a multi-product company. Picking the right one matters.</p>
+<h3>Use Separate Brands When...</h3>
+<p>Your products have their own brand presence in answer engines:</p>
+<ul>
+<li>the products are well-known to answer engines <strong>by their product names</strong></li>
+<li>customers and buyers refer to them directly by product name</li>
+<li>each product has its own distinct competitors</li>
+</ul>
+<p>In this case, model each product as its own brand. Microsoft Word, Microsoft Excel, and Microsoft Teams are different brands to an answer engine — each has its own competitors (Google Docs, Google Sheets, Slack), its own buyer personas, and its own visibility story.</p>
+<p>See <a href="brands.html#multi-product-companies">Brands -&gt; Multi-Product Companies</a>.</p>
+<h3>Use Products When...</h3>
+<p>Your <strong>brand</strong> is strong but your individual products don&#39;t carry their own brand recognition:</p>
+<ul>
+<li>customers know the company name, not the product names</li>
+<li>answer engines describe the products as offerings of the parent brand, not as standalone names</li>
+<li>products often share competitors, or the competitive set isn&#39;t sharply different per product</li>
+<li>you want a single source of truth at the brand level, with product-level slices on top</li>
+</ul>
+<p>In this case, keep everything at the brand level and define <strong>Products</strong> to filter the data per product line.</p>
+<h3>Quick Decision</h3>
+<table>
+<thead><tr><th style="text-align:left">If...</th><th style="text-align:left">Use</th></tr></thead>
+<tbody>
+<tr><td style="text-align:left">Each product has its own brand recognition and distinct competitors</td><td style="text-align:left"><strong>Separate brands</strong></td></tr>
+<tr><td style="text-align:left">The parent brand is strong; products don&#39;t have independent brand presence</td><td style="text-align:left"><strong>Products</strong> (within one brand)</td></tr>
+<tr><td style="text-align:left">You&#39;re not sure</td><td style="text-align:left">Start with one brand + Products. Splitting later is easy; merging later is harder.</td></tr>
+</tbody>
+</table>
+<hr />
+<h2>How Products Work</h2>
+<p>A product is a <strong>named set of topics</strong>. That&#39;s the whole definition.</p>
+<ul>
+<li>Topics can be <strong>shared across products</strong>. The topic <em>&quot;Customer support best practices&quot;</em> might belong to your Sales product and your Service product at the same time.</li>
+<li>Topics that aren&#39;t tied to any product still exist on the brand — they just don&#39;t appear when a product filter is active.</li>
+<li>Products are managed at the brand level. Each brand has its own product list.</li>
+</ul>
+<hr />
+<h2>Where to Set Them Up</h2>
+<p>Products are defined in <strong>Settings</strong>.</p>
+<p>You give each product a name and pick the topics that belong to it. Once at least one product is defined, a <strong>product picker</strong> appears in the main header — letting you switch the entire view between products (or back to the &quot;all products&quot; default).</p>
+<hr />
+<h2>The Product Picker</h2>
+<p>The picker appears in the <strong>main header</strong> only when one or more products are defined for the brand. If you haven&#39;t created any products, the picker stays hidden and Genezio behaves as it always has.</p>
+<p>When you pick a product:</p>
+<ul>
+<li><strong>dashboards</strong> show metrics for the topics in that product</li>
+<li><strong>conversations</strong> filter to that product&#39;s topics</li>
+<li><strong>insights</strong> are scoped to that product&#39;s data</li>
+<li><strong>citations</strong>, <strong>SOV</strong>, <strong>perceptions</strong>, <strong>competitors</strong> — every view narrows to that product</li>
+</ul>
+<p>The default view is <strong>all products</strong> — the brand-wide picture, untouched by any product filter. The picker is an optional lens you opt into.</p>
+<hr />
+<h2>A Typical Setup</h2>
+<p>A consumer-electronics company, for example, with three product lines:</p>
+<ol>
+<li>The company creates one brand for itself.</li>
+<li>In Settings, it defines three products: <em>Headphones</em>, <em>Speakers</em>, <em>Wearables</em>.</li>
+<li>Topics that apply to all three (e.g., <em>&quot;Brand reputation&quot;</em>) are attached to all three products — or left at the brand level if leadership cares about them company-wide.</li>
+<li>Topics specific to one line (e.g., <em>&quot;Noise-cancelling headphones for travel&quot;</em>) belong only to <em>Headphones</em>.</li>
+<li>The product picker appears in the header. The marketing manager for <em>Headphones</em> uses the picker daily to see just their slice; the CMO leaves it on &quot;all products&quot; for the company-wide view.</li>
+</ol>
+<hr />
+<h2>Products and the Rest of the Platform</h2>
+<p>Because the picker filters at the data level, Products work cleanly with the rest of Genezio:</p>
+<ul>
+<li>the <a href="../geo-assistant/geo-assistant.html">Geo Assistant</a> respects the current product filter when answering questions</li>
+<li><a href="../insights/actionable-insights.html">Insights</a> and <a href="../insights/share-of-voice.html">Share of Voice</a> reflect the active product</li>
+<li>exporting reports for stakeholder reviews picks up the product context</li>
+<li><a href="../getting-started/topic-tags.html">Topic Tags</a> still work independently — you can have <em>Headphones</em> (product) and <em>Pricing</em> (tag) on the same topic</li>
+</ul>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="brands.html">Brands</a></li>
+<li><a href="topics.html">Topics</a></li>
+<li><a href="../getting-started/topic-tags.html">Topic Tags</a></li>
+<li><a href="competitors.html">Competitors</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/core-concepts/query-fanouts.html
+++ b/new-landing/public/docs/core-concepts/query-fanouts.html
@@ -1,0 +1,178 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Query Fanouts | Genezio Docs</title>
+  <meta name="description" content="Query Fanouts in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="brands.html">Brands</a></li><li><a class="" href="brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="brand-visibility.html">Brand Visibility</a></li><li><a class="" href="users.html">Users</a></li><li><a class="" href="personas.html">Personas</a></li><li><a class="" href="topics.html">Topics</a></li><li><a class="" href="scenarios.html">Scenarios</a></li><li><a class="" href="topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="conversations.html">Conversations</a></li><li><a class="active" href="query-fanouts.html">Query Fanouts</a></li><li><a class="" href="citations.html">Citations</a></li><li><a class="" href="perceptions.html">Perceptions</a></li><li><a class="" href="competitors.html">Competitors</a></li><li><a class="" href="knowledge-base.html">Knowledge Base</a></li><li><a class="" href="products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Query Fanouts</h1>
+<p>In Genezio, <strong>query fanouts</strong> represent the additional searches that an AI system performs internally while answering a question.</p>
+<p>When a user asks a question, modern AI systems rarely rely on a single query. Instead, they expand the original question into multiple related searches in order to gather more information.</p>
+<p>These additional searches are called <strong>follow-up searches (or query fanouts)</strong>.</p>
+<p>Understanding query fanouts is important because they strongly influence:</p>
+<ul>
+<li>which sources are retrieved</li>
+<li>which brands appear in answers</li>
+<li>which citations are generated</li>
+</ul>
+<hr />
+<h2>Why Query Fanouts Exist</h2>
+<p>User questions are often broad or ambiguous. A single search query may not retrieve enough information for the AI system to generate a useful answer.</p>
+<p>To improve the quality of responses, the AI system expands the original question into several related queries that explore the topic from different angles.</p>
+<p>For example, the question:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>What CRM should a startup use?</strong></em></p></blockquote>
+<p>may internally expand into searches such as:</p>
+<ul>
+<li>best CRM for startups</li>
+<li>startup CRM comparison</li>
+<li>HubSpot vs Pipedrive for startups</li>
+<li>affordable CRM tools for small teams</li>
+</ul>
+<p>Each of these searches retrieves different documents that the AI system can use when constructing its response.</p>
+<hr />
+<h2>Where Query Fanouts Come From</h2>
+<p>The exact search infrastructure used by most AI systems is <strong>not publicly documented</strong>. Outside the companies building these systems, no one knows precisely which search engines or indexes are used to retrieve information.</p>
+<p>However, based on public statements, research papers, and observed behavior, it is widely believed that AI systems rely on a <strong>combination of sources</strong>, such as:</p>
+<ul>
+<li>major web search engines (such as Google or Bing)</li>
+<li>internal search tools built by the AI provider</li>
+<li>open web content databases</li>
+</ul>
+<p>In practice, this means that when an AI system generates fanout queries, those queries may be executed across several different search tools before content is returned to the model.</p>
+<p>Because these systems are constantly evolving, the exact sources used may differ between AI platforms and may change over time. What matters for your content strategy is that <strong>your content needs to be discoverable across multiple search channels</strong>, not just one.</p>
+<hr />
+<h2>How Query Fanouts Influence AI Answers</h2>
+<p>Query fanouts determine which documents are retrieved during the information gathering stage.</p>
+<p>Those documents influence:</p>
+<ul>
+<li>the brands mentioned in the answer</li>
+<li>the sources cited</li>
+<li>the claims included in the response</li>
+</ul>
+<p>For example, if a fanout query retrieves comparison articles that mention specific products, those products are more likely to appear in the generated answer.</p>
+<p>Because of this, query fanouts are one of the strongest signals shaping <strong>AI Recommendations and Visibility</strong>.</p>
+<hr />
+<h2>Query Fanouts in Genezio</h2>
+<p>Genezio detects and extracts query fanouts generated during conversations with AI systems.</p>
+<p>For each conversation, Genezio analyzes:</p>
+<ul>
+<li>the additional queries the AI system explores</li>
+<li>how those queries relate to the original prompt</li>
+<li>which sources are retrieved for each query</li>
+</ul>
+<p>This allows teams to see <strong>what the AI system actually searched for</strong> when answering a question.</p>
+<hr />
+<h2>Example</h2>
+<p>Original prompt:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>What CRM should a startup use?</strong></em></p></blockquote>
+<p>Detected fanout queries might include:</p>
+<ul>
+<li><strong>Query fanout:</strong> <em>best CRM for startups</em></li>
+<li><strong>Query fanout:</strong> <em>CRM tools for SaaS startups</em></li>
+<li><strong>Query fanout:</strong> <em>HubSpot vs Pipedrive</em></li>
+<li><strong>Query fanout:</strong> <em>startup CRM pricing comparison</em></li>
+</ul>
+<p>These queries reveal how the AI system expands the original question in order to build a response.</p>
+<hr />
+<h2>Why Query Fanouts Matter</h2>
+<p>Analyzing fanout queries helps organizations understand:</p>
+<ul>
+<li>how AI systems interpret a topic</li>
+<li>which questions influence AI-generated answers</li>
+<li>which sources shape the information landscape</li>
+<li>where content opportunities exist</li>
+</ul>
+<p>For example, if fanout queries frequently include topics that your brand does not address in its content, this may indicate an opportunity to improve visibility.</p>
+<hr />
+<h2>Query Fanouts vs Keywords</h2>
+<p>Traditional SEO focuses on optimizing pages for specific keywords.</p>
+<p>Query fanouts reflect a broader concept: <strong>how AI systems explore a topic</strong>.</p>
+<p>Instead of relying on a single keyword, AI systems examine multiple related queries before generating an answer.</p>
+<p>Understanding this set of queries provides deeper insight into how AI systems build their responses.</p>
+<hr />
+<h2>Query Fanouts in the Conversation View</h2>
+<p>In Genezio, query fanouts can be inspected in the <strong>conversation detail view</strong>.</p>
+<p>This view shows:</p>
+<ul>
+<li>the original prompt</li>
+<li>the detected fanout queries</li>
+<li>the sources retrieved for those queries</li>
+<li>the final AI response</li>
+</ul>
+<p>This transparency allows users to understand how an AI system arrived at a specific answer.</p>
+<hr />
+<h2>Next Steps</h2>
+<p>To understand how sources retrieved through fanout queries influence answers, see:</p>
+<ul>
+<li><a href="./citations.html">Core Concepts -&gt; Citations</a></li>
+<li><a href="./perceptions.html">Core Concepts -&gt; Perceptions</a></li>
+</ul>
+<p>These pages explain how Genezio extracts structured information from AI responses.</p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/core-concepts/scenarios.html
+++ b/new-landing/public/docs/core-concepts/scenarios.html
@@ -1,0 +1,192 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Scenarios | Genezio Docs</title>
+  <meta name="description" content="Scenarios in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="brands.html">Brands</a></li><li><a class="" href="brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="brand-visibility.html">Brand Visibility</a></li><li><a class="" href="users.html">Users</a></li><li><a class="" href="personas.html">Personas</a></li><li><a class="" href="topics.html">Topics</a></li><li><a class="active" href="scenarios.html">Scenarios</a></li><li><a class="" href="topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="conversations.html">Conversations</a></li><li><a class="" href="query-fanouts.html">Query Fanouts</a></li><li><a class="" href="citations.html">Citations</a></li><li><a class="" href="perceptions.html">Perceptions</a></li><li><a class="" href="competitors.html">Competitors</a></li><li><a class="" href="knowledge-base.html">Knowledge Base</a></li><li><a class="" href="products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Scenarios</h1>
+<p>In Genezio, a <strong>scenario</strong> represents a realistic situation in which a persona is trying to achieve a goal related to a specific topic.</p>
+<p>Scenarios are the <strong>starting point for every conversation</strong> that Genezio runs with an AI system.</p>
+<p>While topics define the general subject area, scenarios describe <strong>the concrete situation that leads a user to ask questions</strong>.</p>
+<hr />
+<h2>Topics vs Scenarios</h2>
+<p>It is important to distinguish between topics and scenarios.</p>
+<p>A <strong>topic</strong> defines the subject area being analyzed.</p>
+<p>Example topic:</p>
+<pre><code>CRM for startups</code></pre>
+<p>A <strong>scenario</strong> is a short story that describes a realistic situation — the persona&#39;s context, constraints, and what they are trying to achieve. Think of it as a brief you would hand someone to explain the full picture.</p>
+<p>Example scenario:</p>
+<pre><code>Mary&#39;s team doesn&#39;t have any technical background. They are looking for a marketing automation platform that is easy for a non-technical team to set up and start using without developer help. Their budget is $800/month and she wants her team of 6 to be able to use it in parallel. She is looking for something that is SOC2 compliant.</code></pre>
+<p>A scenario is <strong>not</strong> a prompt. It is not a question you would send to an AI assistant. Instead, Genezio reads the scenario, combines it with the persona&#39;s details, and generates natural conversational messages from it — the kind a real person would type into ChatGPT or Claude, one at a time.</p>
+<hr />
+<h2>How Scenarios Are Used</h2>
+<p>Every conversation run by Genezio begins with a scenario.</p>
+<p>The process works as follows:</p>
+<ol>
+<li>A <strong>persona</strong> defines who the user is (language, location, context).</li>
+<li>A <strong>topic</strong> defines the subject area.</li>
+<li>A <strong>scenario</strong> defines the situation and the persona&#39;s goal.</li>
+<li>Genezio generates <strong>prompts (messages)</strong> from that scenario.</li>
+<li>Those prompts are sent to the answer engine during the conversation.</li>
+</ol>
+<p>This structure ensures that conversations are grounded in <strong>realistic user contexts rather than abstract prompts</strong>.</p>
+<hr />
+<h2>Scenario Structure</h2>
+<p>A scenario describes the <strong>situation and goal</strong> the persona is experiencing. It should read like a short story — a paragraph full of specific details, constraints, and context.</p>
+<p>A scenario does <strong>not</strong> include details about the persona themselves (such as age, country, occupation, or language). Those are defined separately in the <strong>persona</strong>. The scenario can mention the persona by name, but all other persona details are provided at conversation time.</p>
+<p>This means the persona&#39;s:</p>
+<ul>
+<li>role or profile</li>
+<li>language</li>
+<li>geographic location</li>
+</ul>
+<p>are already defined before the scenario is executed. The scenario focuses entirely on <strong>what is happening</strong> and <strong>what the persona needs</strong>.</p>
+<h3>What to Include</h3>
+<p>A good scenario includes:</p>
+<ul>
+<li><strong>The situation</strong> — what circumstances led to this need (e.g., the team outgrew spreadsheets, a product launch is coming up)</li>
+<li><strong>The goal</strong> — what they want to achieve (e.g., find a tool, compare options, solve a problem)</li>
+<li><strong>Specific constraints</strong> — budget, team size, technical requirements, compliance needs, timeline</li>
+</ul>
+<h3>Goal Description and Intent</h3>
+<p>In addition to the story itself, each scenario carries a <strong>goal description</strong> and an <strong>intent</strong>. The goal description captures, in plain terms, what the persona is ultimately trying to accomplish, while the intent describes the kind of question they are bringing to the AI system (for example, finding a tool, comparing options, or checking a fact).</p>
+<p>These two fields give Genezio extra context when generating messages, which helps it produce <strong>more realistic conversational messages</strong> — questions that are better aligned with what the persona actually wants and how a real person would phrase it.</p>
+<h3>What NOT to Include</h3>
+<p>Do not repeat persona details in the scenario. The persona already defines who the user is. The scenario focuses on <em>why they are asking</em> and <em>what they need</em>.</p>
+<p>This separation allows Genezio to reuse scenarios across different persona contexts while keeping conversations grounded in specific goals.</p>
+<hr />
+<h2>Example: From Scenario to Conversation</h2>
+<p>Here is a complete example showing how a scenario becomes a conversation.</p>
+<p><strong>Topic:</strong> Marketing automation</p>
+<p><strong>Persona:</strong> Marketing manager, located in New York, language: English</p>
+<p><strong>Scenario:</strong></p>
+<pre><code>Mary&#39;s team doesn&#39;t have any technical background. They are looking for a marketing automation platform that is easy for a non-technical team to set up and start using without developer help. Their budget is $800/month and she wants her team of 6 to be able to use it in parallel. She is looking for something that is SOC2 compliant.</code></pre>
+<p>Notice the scenario does not mention Mary&#39;s role, location, or language — those come from the persona.</p>
+<p><strong>What Genezio generates from this scenario:</strong></p>
+<p>Genezio combines the scenario with the persona details and produces natural conversational messages — the kind a real person would send to an AI assistant, one at a time:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>I&#39;m looking for a marketing automation platform that&#39;s easy to set up without any developer help. My team of 6 isn&#39;t very technical. What would you recommend?</strong></em></p></blockquote>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>Our budget is around $800/month and we need all 6 team members to be able to work in the platform at the same time. Which tools support that?</strong></em></p></blockquote>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>Does any of these have SOC2 compliance? That&#39;s a requirement for us.</strong></em></p></blockquote>
+<p>The scenario is the <strong>full story</strong>. The prompts are how a human would naturally unpack that story in a conversation — one question at a time, building on previous answers.</p>
+<hr />
+<h2>Scenarios and Genezio Agents</h2>
+<p>Scenarios are used differently depending on the Genezio Agent type.</p>
+<h3>Prompter Agent</h3>
+<p><strong>Prompter Agent topics</strong> use <strong>prompts</strong>, not scenarios. The prompt is a direct question sent <strong>exactly as written</strong> to the AI system, and the interaction is <strong>single-turn</strong>.</p>
+<h3>Recommender Agent</h3>
+<p>For <strong>Recommender Agent topics</strong>, the scenario defines the starting situation. Genezio generates multiple prompts during the conversation to simulate a realistic recommendation flow.</p>
+<h3>Introspector Agent</h3>
+<p>For <strong>Introspector Agent topics</strong>, the scenario asks about a specific brand directly. If the topic has a persona, the scenario places them in a situation where they want to understand that brand; if the topic has no persona (which is allowed for Introspector — see <a href="../genezio-agents/introspector-agent.html">Introspector Agent</a>), the scenario asks the answer engine to describe the brand with no audience overlay.</p>
+<p>Genezio generates prompts that explore:</p>
+<ul>
+<li>what the brand does</li>
+<li>who it is designed for</li>
+<li>its strengths and weaknesses</li>
+</ul>
+<h3>Comparer Agent</h3>
+<p>For <strong>Comparer Agent topics</strong>, the scenario describes a situation where the persona is evaluating multiple brands.</p>
+<p>Genezio generates prompts that compare those alternatives and analyze their differences.</p>
+<hr />
+<h2>Why Scenarios Matter</h2>
+<p>Scenarios allow Genezio to simulate <strong>real user behavior</strong>.</p>
+<p>In the real world, people rarely ask generic questions like &quot;best CRM&quot;. Instead, they ask questions based on their situation.</p>
+<p>For example:</p>
+<ul>
+<li>a founder looking for their first CRM</li>
+<li>a teenager looking for a debit card</li>
+<li>a runner preparing for a marathon</li>
+</ul>
+<p>By modeling these situations, Genezio can analyze how AI systems respond to <strong>realistic user needs and contexts</strong>.</p>
+<hr />
+<h2>Converting a Scenario to Another Type</h2>
+<p>A good scenario is valuable work — a well-written situation, with the right constraints and goal, takes effort to get right. Genezio lets you <strong>convert a scenario from one type to another</strong> so you can reuse that work across different intents without rewriting it from scratch.</p>
+<p>For example, you can turn a <strong>Prompter</strong> scenario into a <strong>Recommender</strong> one, or move a scenario between any of the five canonical types:</p>
+<ul>
+<li>Prompter</li>
+<li>Recommender</li>
+<li>Introspector</li>
+<li>Comparer</li>
+<li>Fact Checker</li>
+</ul>
+<p>When you convert a scenario, you can also <strong>choose which persona</strong> the converted scenario should use. This is handy when the same underlying situation makes sense for a different audience, or when you want the converted scenario to run from a different perspective.</p>
+<p>The result is that a single, well-crafted scenario can power several types of analysis — letting you explore the same customer situation through recommendation, comparison, introspection, or fact-checking lenses without starting over each time.</p>
+<hr />
+<h2>Restoring Deleted Scenarios</h2>
+<p>Deleting a scenario — or a whole topic — is not permanent. Removed topics and scenarios go to a <strong>Recycle Bin</strong>, where they are kept so they can be <strong>restored</strong> if they were deleted by mistake.</p>
+<p>This means you can clean up your workspace without worrying about losing a carefully written scenario. If you remove something you still need, you can recover it from the Recycle Bin and continue using it as before. For more on managing the topics that scenarios belong to, see <a href="./topics.html">Core Concepts -&gt; Topics</a>.</p>
+<hr />
+<h2>Next Steps</h2>
+<p>To see how scenarios turn into interactions with AI systems, continue with:</p>
+<ul>
+<li><a href="./conversations.html">Core Concepts -&gt; Conversations</a></li>
+</ul>
+<p>This page explains how Genezio executes conversations and analyzes the responses generated by answer engines.</p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/core-concepts/topic-scenario-relevance.html
+++ b/new-landing/public/docs/core-concepts/topic-scenario-relevance.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Topic / Scenario Relevance | Genezio Docs</title>
+  <meta name="description" content="Topic / Scenario Relevance in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="brands.html">Brands</a></li><li><a class="" href="brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="brand-visibility.html">Brand Visibility</a></li><li><a class="" href="users.html">Users</a></li><li><a class="" href="personas.html">Personas</a></li><li><a class="" href="topics.html">Topics</a></li><li><a class="" href="scenarios.html">Scenarios</a></li><li><a class="active" href="topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="conversations.html">Conversations</a></li><li><a class="" href="query-fanouts.html">Query Fanouts</a></li><li><a class="" href="citations.html">Citations</a></li><li><a class="" href="perceptions.html">Perceptions</a></li><li><a class="" href="competitors.html">Competitors</a></li><li><a class="" href="knowledge-base.html">Knowledge Base</a></li><li><a class="" href="products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Topic / Scenario Relevance</h1>
+<p>In Genezio, <strong>Topic / Scenario Relevance</strong> measures how well a scenario captures a real decision context where brands are discussed by AI systems.</p>
+<p>Every <strong>scenario</strong> and <strong>topic</strong> has a Relevance score expressed as a percentage.</p>
+<p>This score helps answer an important question:</p>
+<p><strong>When this scenario is executed, do AI systems actually talk about brands in this category?</strong></p>
+<p>If AI responses frequently mention your brand or competitors, the scenario is considered highly relevant. If responses rarely mention any brands, the scenario is likely poorly framed or unrelated to how users actually ask questions.</p>
+<hr />
+<h2>What Relevance Represents</h2>
+<p>Relevance measures the percentage of conversations where <strong>either your brand or one of your competitors appears</strong>.</p>
+<p>It is calculated as:</p>
+<pre><code>Topic / Scenario Relevance = (Conversations mentioning your brand or competitors / Total conversations) x 100</code></pre>
+<p>Example:</p>
+<ul>
+<li>Conversations executed: 50</li>
+<li>Conversations where at least one brand appears: 40</li>
+</ul>
+<p>Relevance:</p>
+<pre><code>80%</code></pre>
+<p>This means that in 80% of the conversations generated from that scenario, the AI system mentioned at least one relevant brand.</p>
+<hr />
+<h2>Why Topic / Scenario Relevance Matters</h2>
+<p>A scenario is meant to simulate a realistic user situation where someone is evaluating products or services.</p>
+<p>If AI responses do not mention <strong>any brands</strong>, the scenario may not represent a realistic discovery question.</p>
+<p>For example, a vague or poorly framed scenario might lead the AI system to give general advice without recommending products.</p>
+<p>In such cases, the scenario provides little value for competitive analysis.</p>
+<p>Relevance helps identify these cases.</p>
+<hr />
+<h2>Interpreting Relevance Scores</h2>
+<h3>High Relevance (Near 100%)</h3>
+<p>A relevance score close to <strong>100%</strong> indicates that the scenario consistently triggers brand discussions.</p>
+<p>This usually means the scenario is well written and accurately reflects how users ask AI assistants for recommendations.</p>
+<p>These scenarios are ideal for measuring <strong>Brand Visibility</strong> and competitive positioning.</p>
+<hr />
+<h3>Moderate Relevance</h3>
+<p>A mid-range relevance score indicates that brands appear in some responses but not consistently.</p>
+<p>This may suggest that:</p>
+<ul>
+<li>the scenario could be clearer</li>
+<li>the question is somewhat generic</li>
+<li>the AI system sometimes answers without recommending products</li>
+</ul>
+<hr />
+<h3>Low Relevance</h3>
+<p>A low relevance score indicates that AI systems rarely mention any brands in responses.</p>
+<p>This usually means the scenario should be improved.</p>
+<p>Possible issues include:</p>
+<ul>
+<li>the scenario is too abstract</li>
+<li>the question does not imply product discovery</li>
+<li>the user goal is not clearly defined</li>
+</ul>
+<p>Improving the scenario can significantly increase its usefulness for analysis.</p>
+<hr />
+<h2>Scenario-Level vs Topic-Level Relevance</h2>
+<p>Relevance is calculated at two levels.</p>
+<h3>Scenario Relevance</h3>
+<p>Each scenario has its own relevance score based on the conversations generated from that scenario.</p>
+<h3>Topic Relevance</h3>
+<p>Topic relevance is the <strong>average relevance of its scenarios</strong>.</p>
+<p>This helps users understand whether a topic overall is producing meaningful conversations where brands are discussed.</p>
+<hr />
+<h2>Relevance and Scenario Quality</h2>
+<p>Relevance is also a useful indicator of <strong>scenario quality</strong>.</p>
+<p>A well-designed scenario should:</p>
+<ul>
+<li>clearly describe a user situation</li>
+<li>include a realistic goal</li>
+<li>naturally lead to product recommendations</li>
+</ul>
+<p>When these conditions are met, AI systems typically respond with brand suggestions, leading to higher relevance scores.</p>
+<hr />
+<h2>Improving Relevance</h2>
+<p>If a scenario has low relevance, it can often be improved by making the user&#39;s goal more explicit.</p>
+<p>Instead of vague prompts such as:</p>
+<pre><code>Tell me about customer management.</code></pre>
+<p>A stronger scenario might describe a concrete situation such as:</p>
+<pre><code>The persona runs a small startup and needs a tool to manage incoming sales leads and follow up with potential customers.</code></pre>
+<p>This type of situation is more likely to trigger brand recommendations.</p>
+<hr />
+<h2>Why Topic / Scenario Relevance Is Important</h2>
+<p>Relevance ensures that the conversations used to measure AI visibility actually represent <strong>realistic decision-making scenarios</strong>.</p>
+<p>Without relevance filtering, analysis could include conversations where no brands appear, which would make visibility metrics less meaningful.</p>
+<p>By monitoring relevance, teams can continuously refine scenarios and improve the quality of their AI visibility analysis.</p>
+<hr />
+<h2>Next Steps</h2>
+<p>To understand how brand mentions inside relevant conversations contribute to visibility metrics, see:</p>
+<ul>
+<li><a href="./brand-visibility.html">Core Concepts -&gt; Brand Visibility</a></li>
+</ul>
+<p>This page explains how Genezio measures how often your brand appears in AI-generated answers.</p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/core-concepts/topics.html
+++ b/new-landing/public/docs/core-concepts/topics.html
@@ -1,0 +1,220 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Topics | Genezio Docs</title>
+  <meta name="description" content="Topics in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="brands.html">Brands</a></li><li><a class="" href="brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="brand-visibility.html">Brand Visibility</a></li><li><a class="" href="users.html">Users</a></li><li><a class="" href="personas.html">Personas</a></li><li><a class="active" href="topics.html">Topics</a></li><li><a class="" href="scenarios.html">Scenarios</a></li><li><a class="" href="topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="conversations.html">Conversations</a></li><li><a class="" href="query-fanouts.html">Query Fanouts</a></li><li><a class="" href="citations.html">Citations</a></li><li><a class="" href="perceptions.html">Perceptions</a></li><li><a class="" href="competitors.html">Competitors</a></li><li><a class="" href="knowledge-base.html">Knowledge Base</a></li><li><a class="" href="products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Topics</h1>
+<p>In Genezio, a <strong>topic</strong> represents a subject area where users may ask AI assistants questions related to a brand or product category.</p>
+<p>Topics define the <strong>scope of analysis</strong>. They determine which questions Genezio asks AI systems and therefore where a brand&#39;s AI Recommendations and Visibility are measured.</p>
+<p>Most topics belong to a <strong>persona</strong>, meaning that conversations for that topic are executed from the perspective of that persona (including their language and location). The exception is Introspector topics, where a persona is <strong>optional</strong> — see <a href="../genezio-agents/introspector-agent.html">Introspector Agent</a>.</p>
+<hr />
+<h2>What a Topic Represents</h2>
+<p>A topic represents a <strong>problem space or category</strong> where users search for solutions.</p>
+<p>Examples:</p>
+<ul>
+<li>CRM for startups</li>
+<li>running shoes for marathon training</li>
+<li>debit cards for teenagers</li>
+<li>project management tools for small teams</li>
+</ul>
+<p>For each topic, Genezio generates conversations with AI systems to understand:</p>
+<ul>
+<li>which brands are mentioned</li>
+<li>which sources are cited</li>
+<li>how brands are described</li>
+<li>which competitors appear</li>
+</ul>
+<hr />
+<h2>Topics, Scenarios, and Conversations</h2>
+<p>Each topic contains one or more <strong>scenarios</strong>.</p>
+<p>A <strong>scenario</strong> represents a realistic situation in which the persona is trying to achieve a goal related to that topic.</p>
+<p>Scenarios are more detailed than topics. While a topic defines the <strong>subject area</strong>, a scenario describes:</p>
+<ul>
+<li>the persona&#39;s situation</li>
+<li>the persona&#39;s goal</li>
+<li>the context behind the question</li>
+</ul>
+<p>When Genezio runs analysis, <strong>each conversation starts from a scenario</strong>.</p>
+<p>The structure works like this:</p>
+<ol>
+<li>A <strong>topic</strong> defines the subject area (for example: &quot;CRM for startups&quot;).</li>
+<li>A <strong>scenario</strong> describes the persona&#39;s situation and goal.</li>
+<li>Genezio starts a <strong>conversation</strong> with an AI system based on that scenario.</li>
+<li>The conversation then consists of one or more <strong>messages (prompts)</strong> sent to the answer engine.</li>
+</ol>
+<p>For example:</p>
+<p>Topic:</p>
+<pre><code>CRM for startups</code></pre>
+<p>Scenario:</p>
+<pre><code>The persona is a founder of a small SaaS startup with two co-founders. They recently started getting inbound leads and need a simple way to track contacts and follow up with potential customers.</code></pre>
+<p>From that scenario, Genezio may generate prompts such as:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>What CRM would you recommend for a small SaaS startup with only a few sales leads per week?</strong></em></p></blockquote>
+<p>or follow-ups like:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>Which of these tools is easiest to set up for a small team?</strong></em></p></blockquote>
+<p>The <strong>scenario defines the situation</strong>, while <strong>prompts are the individual messages sent to the AI during the conversation</strong>.</p>
+<hr />
+<h2>Genezio Agent Types</h2>
+<p>Genezio supports several Genezio Agent types, each representing a different user intent.</p>
+<h3>Prompter Agent</h3>
+<p>A <strong>Prompter Agent</strong> sends a <strong>single prompt</strong> to the AI system.</p>
+<p>For this agent type, the <strong>scenario itself is the prompt</strong>, and it is sent <strong>word-for-word exactly as defined</strong>.</p>
+<p>The interaction is <strong>single-turn</strong>, meaning there are no follow-up messages.</p>
+<p>Example:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>What CRM should a startup use?</strong></em></p></blockquote>
+<p>Prompter Agent conversations represent the simplest and most direct discovery questions users ask AI systems.</p>
+<hr />
+<h3>Recommender Agent</h3>
+<p>A <strong>Recommender Agent</strong> simulates a user asking the AI system to recommend solutions.</p>
+<p>Unlike the Prompter Agent, the Recommender Agent uses <strong>multi-step conversations</strong>.</p>
+<p>The scenario defines the <strong>situation and goal</strong>, and Genezio generates <strong>multiple prompts during the conversation</strong> to simulate how a real user might interact with the AI assistant.</p>
+<p>Example scenario:</p>
+<pre><code>George runs a small startup and is evaluating tools to manage incoming sales leads.</code></pre>
+<p>From that scenario, Genezio may generate prompts such as:</p>
+<ul>
+<li>asking for tool recommendations</li>
+<li>asking about pricing</li>
+<li>asking which tool is easiest to use</li>
+<li>asking about alternatives</li>
+</ul>
+<p>These interactions simulate realistic recommendation conversations.</p>
+<hr />
+<h3>Introspector Agent</h3>
+<p>An <strong>Introspector Agent</strong> focuses on understanding a specific brand.</p>
+<p>The scenario places the persona in a situation where they want to <strong>learn about a particular product or company</strong>.</p>
+<p>Example scenario:</p>
+<pre><code>Mary has heard about HubSpot but is not sure what it does or whether it would fit their startup.</code></pre>
+<p>Genezio then generates prompts such as:</p>
+<ul>
+<li>asking what the product does</li>
+<li>asking who it is designed for</li>
+<li>asking about advantages and limitations</li>
+</ul>
+<p>These topics help analyze <strong>how AI systems describe and explain a brand</strong>.</p>
+<p>Because the brand name appears in the scenario, Introspector Agent conversations are <strong>not used when calculating AI Visibility</strong>.</p>
+<hr />
+<h3>Comparer Agent</h3>
+<p>A <strong>Comparer Agent</strong> explores how AI systems compare competing brands.</p>
+<p>The scenario places the persona in a situation where they are evaluating alternatives.</p>
+<p>Example scenario:</p>
+<pre><code>I am deciding between HubSpot and Pipedrive for managing startup sales.</code></pre>
+<p>From this scenario, Genezio generates prompts that ask the AI to:</p>
+<ul>
+<li>compare the two products</li>
+<li>highlight strengths and weaknesses</li>
+<li>recommend which option is better for the persona&#39;s situation</li>
+</ul>
+<p>These conversations help analyze <strong>competitive positioning</strong> in AI answers.</p>
+<p>Because the brands appear in the scenario itself, Comparer Agent conversations are <strong>not used when calculating AI Visibility or AI Recommendations</strong>. The Comparer is a <strong>competitive analysis tool</strong> — it consumes the brand-level KPIs that Genezio has already calculated from Prompter and Recommender conversations and uses them to show how your brand stacks up against specific competitors.</p>
+<hr />
+<h2>Single-Turn vs Multi-Turn Agent Types</h2>
+<p>Genezio Agent types differ in how conversations are executed.</p>
+<ul>
+<li><strong>Prompter Agent:</strong> Single prompt sent exactly as written</li>
+<li><strong>Recommender Agent:</strong> Multi-step conversation generated from a scenario</li>
+<li><strong>Introspector Agent:</strong> Multi-step conversation exploring a brand</li>
+<li><strong>Comparer Agent:</strong> Multi-step conversation comparing brands</li>
+</ul>
+<p>This combination allows Genezio to simulate both <strong>simple discovery queries</strong> and <strong>realistic conversational research behavior</strong>.</p>
+<hr />
+<h2>How Topics Are Created</h2>
+<p>During onboarding, Genezio automatically generates an initial set of topics based on:</p>
+<ul>
+<li>the brand description</li>
+<li>the customer persona</li>
+<li>the product category</li>
+</ul>
+<p>Users can then:</p>
+<ul>
+<li>edit topics</li>
+<li>add additional topics</li>
+<li>remove irrelevant topics</li>
+</ul>
+<p>Over time, teams often expand their topics to cover additional markets, products, or user intents.</p>
+<hr />
+<h2>Why Topics Matter</h2>
+<p>Topics define <strong>where your brand&#39;s AI Recommendations and Visibility are measured</strong>.</p>
+<p>A brand may have strong visibility in some topics but low visibility in others.</p>
+<p>For example:</p>
+<ul>
+<li>strong visibility for &quot;CRM for startups&quot;</li>
+<li>weaker visibility for &quot;sales automation platforms&quot;</li>
+</ul>
+<p>Analyzing topics separately helps organizations identify <strong>where they are well represented in AI answers and where opportunities exist</strong>.</p>
+<hr />
+<h2>Next Steps</h2>
+<p>To understand how topics are used to generate AI conversations, see:</p>
+<ul>
+<li><a href="./scenarios.html">Core Concepts -&gt; Scenarios</a></li>
+<li><a href="./conversations.html">Core Concepts -&gt; Conversations</a></li>
+</ul>
+<p>These pages explain how Genezio converts topics into structured AI interactions.</p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/core-concepts/users.html
+++ b/new-landing/public/docs/core-concepts/users.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Users | Genezio Docs</title>
+  <meta name="description" content="Users in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="brands.html">Brands</a></li><li><a class="" href="brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="brand-visibility.html">Brand Visibility</a></li><li><a class="active" href="users.html">Users</a></li><li><a class="" href="personas.html">Personas</a></li><li><a class="" href="topics.html">Topics</a></li><li><a class="" href="scenarios.html">Scenarios</a></li><li><a class="" href="topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="conversations.html">Conversations</a></li><li><a class="" href="query-fanouts.html">Query Fanouts</a></li><li><a class="" href="citations.html">Citations</a></li><li><a class="" href="perceptions.html">Perceptions</a></li><li><a class="" href="competitors.html">Competitors</a></li><li><a class="" href="knowledge-base.html">Knowledge Base</a></li><li><a class="" href="products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Users</h1>
+<p>In Genezio, <strong>users</strong> are the people who can access and work inside an account.</p>
+<p>Users can be invited at:</p>
+<ul>
+<li><strong>account level</strong> (access to all brands in the account)</li>
+<li><strong>brand level</strong> (access only to selected brands)</li>
+</ul>
+<p>This allows teams to control collaboration and visibility across multiple brands.</p>
+<hr />
+<h2>Account-Level Users</h2>
+<p>Account-level users are invited to the full account workspace.</p>
+<p>This is useful for team members who need broad visibility, such as:</p>
+<ul>
+<li>account owners</li>
+<li>operations leads</li>
+<li>central growth or analytics teams</li>
+</ul>
+<hr />
+<h2>Brand-Level Users</h2>
+<p>Brand-level users are invited to one or more specific brands.</p>
+<p>This is useful when access should be limited, for example:</p>
+<ul>
+<li>client stakeholders who should see only their brand</li>
+<li>agency specialists assigned to selected client brands</li>
+<li>internal teams responsible for one product line</li>
+</ul>
+<hr />
+<h2>Why This Matters</h2>
+<p>User access design affects both governance and day-to-day execution.</p>
+<p>Clear user assignment helps teams:</p>
+<ul>
+<li>prevent accidental exposure across brands</li>
+<li>keep ownership and accountability clear</li>
+<li>collaborate faster within the right scope</li>
+</ul>
+<hr />
+<h2>Next Steps</h2>
+<p>To continue, see:</p>
+<ul>
+<li><a href="./brands.html">Core Concepts -&gt; Brands</a></li>
+<li><a href="./personas.html">Core Concepts -&gt; Personas</a></li>
+<li><a href="./topics.html">Core Concepts -&gt; Topics</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/genezio-agents/comparer-agent.html
+++ b/new-landing/public/docs/genezio-agents/comparer-agent.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Comparer Agent | Genezio Docs</title>
+  <meta name="description" content="Comparer Agent in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="prompter-agent.html">Prompter Agent</a></li><li><a class="" href="recommender-agent.html">Recommender Agent</a></li><li><a class="" href="introspector-agent.html">Introspector Agent</a></li><li><a class="active" href="comparer-agent.html">Comparer Agent</a></li><li><a class="" href="fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Comparer Agent</h1>
+<p>The <strong>Comparer Agent</strong> is a Genezio Agent type used to evaluate how AI systems compare multiple brands in the same conversation.</p>
+<p>It is designed for competitive positioning analysis.</p>
+<hr />
+<h2>How It Works</h2>
+<p>For a Comparer Agent topic:</p>
+<ul>
+<li>you select the exact competitors you want to be compared against (at the topic level)</li>
+<li>the scenario names your brand and those competitors</li>
+<li>Genezio runs a multi-step comparison conversation</li>
+<li>prompts ask for differences, tradeoffs, and best-fit recommendations</li>
+</ul>
+<p>Selecting competitors per topic ensures that auto-generated Comparer scenarios target the brands that actually matter for that subject area, rather than any competitor that happens to surface in AI answers.</p>
+<p>Example scenario:</p>
+<pre><code>Alex is evaluating HubSpot and Pipedrive for his sales team of five. He needs a CRM that is easy to onboard, has good reporting, and works well with their existing email workflow. He wants to understand the key differences before making a decision.</code></pre>
+<p>From this scenario, Genezio generates conversational messages such as:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>I&#39;m comparing HubSpot and Pipedrive for a sales team of five. What are the main differences between the two?</strong></em></p></blockquote>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>Which one is easier to onboard for a small team with no CRM experience?</strong></em></p></blockquote>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>How do they compare on reporting and email integration?</strong></em></p></blockquote>
+<hr />
+<h2>Typical Use Cases</h2>
+<p>Comparer Agent conversations help teams understand:</p>
+<ul>
+<li>which competitor is favored in side-by-side comparisons</li>
+<li>how AI systems frame strengths and weaknesses per brand</li>
+<li>what objections or limitations are repeatedly mentioned</li>
+</ul>
+<hr />
+<h2>What You Can Learn from Comparer</h2>
+<p>Using Comparer, you can:</p>
+<ul>
+<li>See how answer engines frame your brand against specific competitors</li>
+<li>Compare recommendation and visibility rates side by side</li>
+<li>Identify the strengths and weaknesses AI associates with each brand</li>
+<li>Generate SWOT-style insights to guide your competitive content strategy</li>
+</ul>
+<p>Genezio automatically extracts a <strong>SWOT analysis</strong> from every Comparer conversation and displays it inline in the conversation drawer. The same SWOT is aggregated at the scenario and topic level, and an overall <strong>SWOT Comparison</strong> view is available from the menu under <strong>Competitors -&gt; SWOT</strong>, showing SWOTs for your brand and all tracked competitors side by side. See <a href="../insights/swot-analysis.html">Insights -&gt; SWOT Analysis</a> for the full breakdown.</p>
+<p>The result is a clear view of where you&#39;re winning, where you&#39;re losing, and what narratives are driving the difference.</p>
+<hr />
+<h2>KPI Impact</h2>
+<p>Comparer Agent conversations <strong>do not count toward AI Recommendations or AI Visibility</strong>. Because the brand names appear in the prompt, including them would distort the metrics.</p>
+<p>Instead, the Comparer is a <strong>competitive analysis tool</strong>. It consumes the brand-level KPIs that Genezio has already calculated from Prompter and Recommender conversations, and uses them alongside head-to-head AI conversations to show how your brand stacks up against specific competitors.</p>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="../insights/swot-analysis.html">Insights -&gt; SWOT Analysis</a></li>
+<li><a href="../core-concepts/competitors.html">Core Concepts -&gt; Competitors</a></li>
+<li><a href="../core-concepts/brand-visibility.html">Core Concepts -&gt; Brand Visibility</a></li>
+<li><a href="../analysis/running-conversations.html">Conversation Analysis -&gt; Running Conversations</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/genezio-agents/fact-checker-agent.html
+++ b/new-landing/public/docs/genezio-agents/fact-checker-agent.html
@@ -1,0 +1,158 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Fact Checker Agent | Genezio Docs</title>
+  <meta name="description" content="Fact Checker Agent in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="prompter-agent.html">Prompter Agent</a></li><li><a class="" href="recommender-agent.html">Recommender Agent</a></li><li><a class="" href="introspector-agent.html">Introspector Agent</a></li><li><a class="" href="comparer-agent.html">Comparer Agent</a></li><li><a class="active" href="fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Fact Checker Agent</h1>
+<p>The <strong>Fact Checker Agent</strong> is the third major axis of measurement in Genezio, alongside Visibility and Recommendation.</p>
+<p>Visibility asks <em>how often you appear</em>. Recommendation asks <em>how often you&#39;re picked</em>. Fact Checker asks a different question:</p>
+<blockquote><p><strong>When answer engines talk about your brand, do they get the facts right?</strong></p></blockquote>
+<p>You feed in specific verifiable claims about your brand — pricing, features, founding year, customer counts, certifications, anything that can be true or false — and the platform tests them against every supported answer engine.</p>
+<hr />
+<h2>Why Fact Checker Exists</h2>
+<p>Answer engines hallucinate. They mix outdated information with current. They confuse brands with similar ones. For most brands this is annoying. For some — security companies, financial services, regulated industries, healthcare, anyone whose product details <em>have to</em> be accurate — it&#39;s a real risk.</p>
+<p>Until Fact Checker, there was no way to systematically monitor what answer engines are saying about specific facts. You&#39;d find out about a hallucinated claim only when a customer mentioned it, or when someone happened to ask the right question.</p>
+<p>Fact Checker turns that into measurement: you list the claims you care about, and the platform reports, per claim, per engine, whether each engine confirms it, contradicts it, or doesn&#39;t engage with it.</p>
+<hr />
+<h2>How It Works</h2>
+<p>A Fact Checker topic carries a set of <strong>claims to verify</strong> — claims you assert are true about your brand. For each claim, the platform runs conversations with every supported answer engine and classifies the response into one of three outcomes:</p>
+<ul>
+<li><strong>True</strong> — the engine confirms the claim</li>
+<li><strong>False</strong> — the engine contradicts the claim</li>
+<li><strong>Indecisive</strong> — the engine doesn&#39;t take a clear position either way</li>
+</ul>
+<p>This three-state outcome is per-claim <strong>and</strong> per-engine, so a single claim can be confirmed by ChatGPT, contradicted by Perplexity, and ignored by Claude — and you&#39;d see that in the platform.</p>
+<hr />
+<h2>Where Claims Come From</h2>
+<p>You have two ways to feed claims into a Fact Checker topic:</p>
+<h3>From the Knowledge Base</h3>
+<p>Pull claims from your brand&#39;s <a href="../core-concepts/knowledge-base.html">Knowledge Base</a> — the documents, URLs, and snippets that already represent your source of truth. This is the natural way to operate once your KB is populated: the truth is already documented, and Fact Checker just measures whether answer engines reflect it.</p>
+<h3>Custom Claims</h3>
+<p>Type in claims directly on the Fact Checker topic. Useful for one-off measurements (&quot;does ChatGPT know we acquired Company X last quarter?&quot;), for testing claims that aren&#39;t yet in the KB, or for monitoring specific high-risk facts (a certification, a regulatory status, a pricing detail).</p>
+<p>You can mix both on a single topic — some claims sourced from the KB, others typed in directly.</p>
+<hr />
+<h2>Where You See Results</h2>
+<h3>On the Conversation</h3>
+<p>Each conversation has a dedicated <strong>Fact Checker tab</strong> showing which claims the answer engine claimed and which it didn&#39;t. Cards show a clean <strong>CLAIMED / NOT CLAIMED</strong> label so you can scan a single conversation quickly.</p>
+<h3>On the Topic and Scenario Drawers</h3>
+<p>Open the <strong>View More</strong> drawer on a topic or scenario and you&#39;ll find Fact Checker charts, including a <strong>&quot;Claimed metric by answer engine&quot;</strong> breakdown — which engines back your claims and which ones don&#39;t. This is the view you want when reporting up: a snapshot of whose facts are being confirmed across the engine landscape.</p>
+<hr />
+<h2>KPI Impact</h2>
+<p>Fact Checker conversations <strong>do not count toward AI Visibility or AI Recommendations</strong>.</p>
+<p>The brand and the claims are named explicitly in the prompt, so the conversations don&#39;t measure organic discovery — they measure accuracy. Including them in the KPIs would distort the metrics.</p>
+<p>Like Introspector and Comparer, Fact Checker is a <strong>measurement tool of its own</strong>: separate from visibility and recommendation, but every bit as useful for the right brand.</p>
+<hr />
+<h2>The Accuracy Stack</h2>
+<p>Fact Checker is the final piece of Genezio&#39;s accuracy stack:</p>
+<ol>
+<li><strong><a href="../core-concepts/knowledge-base.html">Knowledge Base</a></strong> — defines what&#39;s true about your brand</li>
+<li><strong><a href="../core-concepts/perceptions.html">Grounded Perceptions</a></strong> — show whether claims pulled from organic conversations match your KB</li>
+<li><strong>Fact Checker</strong> — actively tests whether answer engines confirm specific claims when asked</li>
+</ol>
+<p>Together, these give you a complete view of accuracy:</p>
+<ul>
+<li>the <strong>KB</strong> is the source of truth</li>
+<li><strong>Grounded Perceptions</strong> measure what answer engines <em>spontaneously</em> say about you</li>
+<li><strong>Fact Checker</strong> measures what answer engines say <em>when asked directly</em></li>
+</ul>
+<p>The first observes; the second probes. Read them together and you know both the narrative answer engines volunteer and the answers they give when pushed.</p>
+<hr />
+<h2>When to Use Fact Checker</h2>
+<p>Fact Checker is most valuable for brands where factual accuracy directly affects buyer trust or regulatory standing:</p>
+<ul>
+<li><strong>Security and financial services</strong> — where misstatements about certifications, compliance, or features can cost trust</li>
+<li><strong>Healthcare and regulated industries</strong> — where claims about products carry legal weight</li>
+<li><strong>Brands with frequently-confused competitors</strong> — where engines mix your facts with someone else&#39;s</li>
+<li><strong>Brands after a major change</strong> — new pricing, an acquisition, a rebrand — where stale information lingers in answer engines for months</li>
+<li><strong>Any brand worried about hallucinated misinformation</strong> — Fact Checker turns that worry into a measured signal</li>
+</ul>
+<hr />
+<h2>Typical Workflow</h2>
+<ol>
+<li><strong>Populate the Knowledge Base</strong> (or have it ready) — the truth source you&#39;ll measure against.</li>
+<li><strong>Create a Fact Checker topic</strong> — attach KB-sourced claims, custom claims, or both.</li>
+<li><strong>Run the topic</strong> — conversations execute against every supported answer engine.</li>
+<li><strong>Read the results</strong> — Conversation tab for individual outcomes; topic/scenario drawer charts for cross-engine summaries.</li>
+<li><strong>Act on false outcomes</strong> — fix the underlying public content (your website, your docs, third-party listings) so answer engines have the right information to retrieve next time.</li>
+<li><strong>Re-run periodically</strong> — answer engines evolve. Yesterday&#39;s confirmed claim can become tomorrow&#39;s contradiction.</li>
+</ol>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="../core-concepts/knowledge-base.html">Core Concepts -&gt; Knowledge Base</a></li>
+<li><a href="../core-concepts/perceptions.html">Core Concepts -&gt; Perceptions</a></li>
+<li><a href="prompter-agent.html">Prompter Agent</a></li>
+<li><a href="recommender-agent.html">Recommender Agent</a></li>
+<li><a href="introspector-agent.html">Introspector Agent</a></li>
+<li><a href="comparer-agent.html">Comparer Agent</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/genezio-agents/introspector-agent.html
+++ b/new-landing/public/docs/genezio-agents/introspector-agent.html
@@ -1,0 +1,134 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Introspector Agent | Genezio Docs</title>
+  <meta name="description" content="Introspector Agent in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="prompter-agent.html">Prompter Agent</a></li><li><a class="" href="recommender-agent.html">Recommender Agent</a></li><li><a class="active" href="introspector-agent.html">Introspector Agent</a></li><li><a class="" href="comparer-agent.html">Comparer Agent</a></li><li><a class="" href="fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Introspector Agent</h1>
+<p>The <strong>Introspector Agent</strong> is a Genezio Agent type focused on understanding how AI systems describe a specific brand.</p>
+<p>It is used for brand explanation and positioning analysis, not for organic visibility measurement.</p>
+<hr />
+<h2>How It Works</h2>
+<p>For an Introspector Agent topic:</p>
+<ul>
+<li>the scenario explicitly includes the target brand</li>
+<li>a persona is <strong>optional</strong> (see below)</li>
+<li>Genezio runs a multi-step conversation about that brand</li>
+<li>prompts explore use cases, fit, strengths, and limitations</li>
+</ul>
+<h3>Persona Is Optional</h3>
+<p>Introspector topics can run <strong>with or without a persona</strong>.</p>
+<p>Because Introspector is essentially asking &quot;what does the answer engine say about us when asked directly?&quot;, the brand name is already in the prompt — and the persona overlay isn&#39;t always needed to get a meaningful answer. Skipping the persona removes a setup step for the common case where you just want to know how answer engines describe your brand, full stop.</p>
+<p>When to <strong>add</strong> a persona to an Introspector topic:</p>
+<ul>
+<li>you want to know how the description changes when asked from a specific region, language, or buyer profile</li>
+<li>you&#39;re auditing how the brand is positioned for a specific audience segment</li>
+</ul>
+<p>When to <strong>skip</strong> the persona:</p>
+<ul>
+<li>you want a baseline read of how answer engines describe your brand, with no audience overlay</li>
+<li>you&#39;re setting up Introspector quickly and don&#39;t have a relevant persona yet</li>
+</ul>
+<p>This makes Introspector the lightest-weight agent to configure: a topic, the brand name, and you&#39;re ready to run.</p>
+<p>Example scenario:</p>
+<pre><code>Sarah has heard about HubSpot from a colleague and wants to understand what it actually does before evaluating it. She wants to know what types of teams use it, what its main strengths are, and whether it has any notable limitations.</code></pre>
+<p>From this scenario, Genezio generates conversational messages such as:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>What is HubSpot mainly used for? What kind of teams typically use it?</strong></em></p></blockquote>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>What are HubSpot&#39;s main strengths compared to other tools in its category?</strong></em></p></blockquote>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>Are there any common limitations or complaints about HubSpot?</strong></em></p></blockquote>
+<hr />
+<h2>Typical Use Cases</h2>
+<p>Introspector Agent conversations help teams analyze:</p>
+<ul>
+<li>how AI systems explain a brand&#39;s category and value</li>
+<li>recurring strengths or weaknesses in brand narratives</li>
+<li>consistency of brand framing across answer engines</li>
+</ul>
+<hr />
+<h2>Visibility KPI Impact</h2>
+<p>Introspector Agent conversations are <strong>excluded</strong> from Brand Visibility calculations because the brand name is already present in the prompt.</p>
+<p>Including these conversations would inflate visibility results.</p>
+<hr />
+<h2>Why It Still Matters</h2>
+<p>Even though it is excluded from visibility KPIs, this agent is valuable for:</p>
+<ul>
+<li>narrative quality review</li>
+<li>positioning audits</li>
+<li>messaging consistency analysis</li>
+</ul>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="../core-concepts/perceptions.html">Core Concepts -&gt; Perceptions</a></li>
+<li><a href="../core-concepts/brand-visibility.html">Core Concepts -&gt; Brand Visibility</a></li>
+<li><a href="../core-concepts/conversations.html">Core Concepts -&gt; Conversations</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/genezio-agents/prompter-agent.html
+++ b/new-landing/public/docs/genezio-agents/prompter-agent.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Prompter Agent | Genezio Docs</title>
+  <meta name="description" content="Prompter Agent in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="active" href="prompter-agent.html">Prompter Agent</a></li><li><a class="" href="recommender-agent.html">Recommender Agent</a></li><li><a class="" href="introspector-agent.html">Introspector Agent</a></li><li><a class="" href="comparer-agent.html">Comparer Agent</a></li><li><a class="" href="fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Prompter Agent</h1>
+<p>The <strong>Prompter Agent</strong> is a Genezio Agent type that runs a single-turn interaction with an AI system.</p>
+<p>It is designed to test direct discovery-style queries where a user asks one clear question and receives one answer.</p>
+<hr />
+<h2>How It Works</h2>
+<p>For a Prompter Agent topic:</p>
+<ul>
+<li>the prompt is sent to the AI system word-for-word</li>
+<li>no follow-up messages are generated</li>
+</ul>
+<p>Unlike other agent types, Prompter Agent topics use <strong>prompts</strong>, not scenarios. A prompt is a direct question — the kind a real user would type into an AI assistant.</p>
+<p>Example prompt:</p>
+<pre><code>What CRM should a startup with a small sales team use to track leads and follow up with customers?</code></pre>
+<p>This text is sent directly to the AI system as a single message.</p>
+<hr />
+<h2>Typical Use Cases</h2>
+<p>Prompter Agent conversations are useful when you want to measure:</p>
+<ul>
+<li>which brands are mentioned in direct discovery questions</li>
+<li>whether your brand appears in first-pass recommendations</li>
+<li>how different answer engines respond to the same prompt</li>
+</ul>
+<hr />
+<h2>Visibility Impact</h2>
+<p>Prompter Agent conversations are included in <strong>Brand Visibility</strong> and related visibility KPIs because the AI system must choose brands organically, without brand names being forced into the prompt.</p>
+<hr />
+<h2>Single-Turn Behavior</h2>
+<p>Because Prompter Agent conversations are single-turn:</p>
+<ul>
+<li>they are easy to compare across engines</li>
+<li>they reduce variability from follow-up prompts</li>
+<li>they provide a clean baseline for visibility tracking over time</li>
+</ul>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="../core-concepts/topics.html">Core Concepts -&gt; Topics</a></li>
+<li><a href="../core-concepts/scenarios.html">Core Concepts -&gt; Scenarios</a></li>
+<li><a href="../core-concepts/brand-visibility.html">Core Concepts -&gt; Brand Visibility</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/genezio-agents/recommender-agent.html
+++ b/new-landing/public/docs/genezio-agents/recommender-agent.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Recommender Agent | Genezio Docs</title>
+  <meta name="description" content="Recommender Agent in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="prompter-agent.html">Prompter Agent</a></li><li><a class="active" href="recommender-agent.html">Recommender Agent</a></li><li><a class="" href="introspector-agent.html">Introspector Agent</a></li><li><a class="" href="comparer-agent.html">Comparer Agent</a></li><li><a class="" href="fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Recommender Agent</h1>
+<p>The <strong>Recommender Agent</strong> is a Genezio Agent type that simulates recommendation-seeking behavior in multi-step AI conversations.</p>
+<p>It is designed for scenarios where a persona is trying to find a specific solution that fits their needs and constraints.</p>
+<hr />
+<h2>How It Works</h2>
+<p>For a Recommender Agent topic:</p>
+<ul>
+<li>the scenario defines the user situation and goal</li>
+<li>Genezio generates a sequence of prompts from that scenario</li>
+<li>the AI conversation runs across multiple turns</li>
+</ul>
+<p>Example scenario:</p>
+<pre><code>John&#39;s team of three has been tracking leads in a spreadsheet but they are losing follow-ups as inbound volume grows. They need a simple CRM that integrates with Gmail and costs under $50/user/month.</code></pre>
+<p>From this scenario, Genezio generates conversational messages such as:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>I run a small startup and we&#39;ve been tracking leads in a spreadsheet, but it&#39;s not working anymore. What CRM tools would you recommend for a team of three?</strong></em></p></blockquote>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>We need something that integrates with Gmail and stays under $50 per user per month. Which of those would fit?</strong></em></p></blockquote>
+<hr />
+<h2>Typical Use Cases</h2>
+<p>Recommender Agent conversations are useful when you want to evaluate:</p>
+<ul>
+<li>recommendation frequency for your brand</li>
+<li>how your brand is positioned against competitors</li>
+<li>how recommendations change after follow-up constraints</li>
+</ul>
+<hr />
+<h2>KPI Impact</h2>
+<p>Recommender Agent conversations are a core input to:</p>
+<ul>
+<li><strong>AI Recommendations</strong> - percentage of Recommender Agent conversations where your brand is recommended</li>
+<li><strong>Brand Visibility</strong> - included because brands are selected by the AI, not forced by prompt wording</li>
+</ul>
+<hr />
+<h2>Multi-Step Behavior</h2>
+<p>Multi-step flow makes this agent useful for realistic buyer journeys:</p>
+<ul>
+<li>initial broad recommendation</li>
+<li>filtering by budget, features, or team size</li>
+<li>shortlisting alternatives</li>
+</ul>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="../introduction/what-kpis-are-we-measuring.html">Introduction -&gt; What KPIs Are We Measuring</a></li>
+<li><a href="../core-concepts/topics.html">Core Concepts -&gt; Topics</a></li>
+<li><a href="../core-concepts/conversations.html">Core Concepts -&gt; Conversations</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/geo-assistant/actions-geo-can-take.html
+++ b/new-landing/public/docs/geo-assistant/actions-geo-can-take.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Actions Geo Can Take | Genezio Docs</title>
+  <meta name="description" content="Actions Geo Can Take in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="geo-assistant.html">Geo Assistant</a></li><li><a class="" href="send-to-geo.html">Send to Geo</a></li><li><a class="" href="sessions-and-history.html">Sessions and History</a></li><li><a class="active" href="actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Actions Geo Can Take</h1>
+<p>Geo isn&#39;t only a read-and-summarize assistant. It can also <strong>take actions</strong> inside the Genezio platform — creating, refining, and moving objects on your behalf, with your account&#39;s permissions.</p>
+<p>This is what turns Geo from a chat layer into the connective tissue between investigation, decision, and deliverable.</p>
+<hr />
+<h2>Read vs. Action</h2>
+<p>Most Geo answers are powered by <strong>read tools</strong> — the same data endpoints that drive the dashboard&#39;s charts and drawers. Geo decides which to call, runs them, and synthesizes the result.</p>
+<p>A subset of Geo&#39;s tools are <strong>action tools</strong>. These don&#39;t just look at your data — they <strong>change</strong> it. When Geo proposes an action, it&#39;s making a real edit to your account.</p>
+<p>You see the action in the tool-call trace, the same way you see read calls (see <a href="sessions-and-history.html">Sessions and History</a>).</p>
+<hr />
+<h2>What Geo Can Do</h2>
+<p>The action tools available to Geo include:</p>
+<h3>Manage Brands and Competitors</h3>
+<ul>
+<li><strong>Move a brand entry</strong> — promote, demote, merge, or attach competitor entries based on what Geo finds in the data</li>
+<li><strong>Reclassify a detected brand</strong> — convert a mistakenly-tracked competitor into a sub-brand of yours, or vice versa</li>
+</ul>
+<h3>Manage Personas</h3>
+<ul>
+<li><strong>Create a persona</strong> — when Geo finds a missing audience segment, it can scaffold a new persona with name, role, country, city, and language</li>
+<li><strong>Update a persona</strong> — adjust attributes when scenarios suggest the existing persona doesn&#39;t fit</li>
+</ul>
+<h3>Manage Topics and Scenarios</h3>
+<ul>
+<li><strong>Refine a topic</strong> — adjust its description, persona assignment, or competitor selection</li>
+<li><strong>Create a scenario</strong> — draft a new scenario for an existing topic when Geo identifies an uncovered intent</li>
+<li><strong>Update a scenario</strong> — tighten wording, change the Agent type, or adjust which competitors a Comparer scenario targets</li>
+<li><strong>Restore deleted topics or scenarios</strong> — recover an object from the Recycle Bin when it was removed by mistake</li>
+</ul>
+<h3>Produce Content</h3>
+<ul>
+<li><strong>Generate a brief</strong> — hand off Geo&#39;s findings to Content Hub as a structured brief (audience, tone, keywords, competitors, scenarios, instructions)</li>
+<li><strong>Trigger article generation</strong> — start a full article in Content Hub grounded in the context of the current conversation</li>
+</ul>
+<p>See <a href="../content-hub/briefs.html">Content Hub -&gt; Briefs</a> for what gets generated.</p>
+<h3>Explore CDN Logs</h3>
+<ul>
+<li><strong>Explore CDN logs</strong> — surface log clusters and the AI-crawler breakdown, so you can see how AI crawlers are reaching your site without leaving the conversation</li>
+</ul>
+<hr />
+<h2>How Actions Get Triggered</h2>
+<p>You don&#39;t have to ask for actions by name. Geo decides when an action is appropriate based on the conversation. For example:</p>
+<ul>
+<li>You ask: <em>&quot;This competitor X is actually a product line we own — fix that.&quot;</em> Geo proposes attaching the brand to yours and executes the move.</li>
+<li>You ask: <em>&quot;We&#39;re missing a persona for European mid-market buyers.&quot;</em> Geo drafts a new persona and creates it.</li>
+<li>You ask: <em>&quot;Draft a brief that counters their top SWOT strength.&quot;</em> Geo composes the brief and hands it to Content Hub.</li>
+</ul>
+<p>The action runs with <strong>your account&#39;s permissions</strong> — Geo cannot do anything you couldn&#39;t do yourself in the UI.</p>
+<hr />
+<h2>Auditing Actions</h2>
+<p>Every action Geo takes appears in the session&#39;s tool-call trace, alongside read calls. You can see:</p>
+<ul>
+<li>what action was invoked</li>
+<li>what parameters it ran with (the object affected, the new values)</li>
+<li>the result</li>
+</ul>
+<p>This means actions taken by Geo are as auditable as any change made directly in the UI.</p>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="geo-assistant.html">Geo Assistant</a></li>
+<li><a href="sessions-and-history.html">Sessions and History</a></li>
+<li><a href="send-to-geo.html">Send to Geo</a></li>
+<li><a href="../content-hub/briefs.html">Content Hub -&gt; Briefs</a></li>
+<li><a href="../core-concepts/personas.html">Core Concepts -&gt; Personas</a></li>
+<li><a href="../core-concepts/competitors.html">Core Concepts -&gt; Competitors</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/geo-assistant/geo-assistant.html
+++ b/new-landing/public/docs/geo-assistant/geo-assistant.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Geo Assistant | Genezio Docs</title>
+  <meta name="description" content="Geo Assistant in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="active" href="geo-assistant.html">Geo Assistant</a></li><li><a class="" href="send-to-geo.html">Send to Geo</a></li><li><a class="" href="sessions-and-history.html">Sessions and History</a></li><li><a class="" href="actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Geo Assistant</h1>
+<p><strong>Geo</strong> is the conversational layer of the Genezio platform — a chat-with-your-data assistant, embedded in the dashboard, with live access to every metric, conversation, citation, competitor, perception, and SWOT entry Genezio has collected for your brand.</p>
+<p>The name comes from <strong>GEO</strong> — Generative Engine Optimization, the AI-era counterpart to SEO. Genezio is a GEO platform; Geo is the assistant on top of it.</p>
+<hr />
+<h2>Why Geo Exists</h2>
+<p>A typical brand running on Genezio accumulates a lot of data — hundreds of topics, thousands of LLM conversations per month, citations from dozens of sources, competitor mentions across multiple answer engines, sentiment trends per region, persona, and language.</p>
+<p>Manually pivoting through that to answer day-to-day business questions is slow. Geo turns those questions into a chat. You ask in plain language; Geo runs the right queries against your data and answers, citing what it used.</p>
+<p>Typical questions:</p>
+<ul>
+<li>&quot;Am I winning or losing share of voice this month, and against whom?&quot;</li>
+<li>&quot;Which LLM is hurting me most, and on which topics?&quot;</li>
+<li>&quot;Why did my recommendation rate drop on ChatGPT last week?&quot;</li>
+<li>&quot;Which citation sources are driving negative sentiment about us?&quot;</li>
+<li>&quot;What&#39;s a competitor doing in Perplexity that we&#39;re not?&quot;</li>
+<li>&quot;Give me three content ideas that would close the gap on topic X.&quot;</li>
+</ul>
+<hr />
+<h2>What You Can Do With Geo</h2>
+<h3>Investigate</h3>
+<p>Notice a metric move on a chart — a recommendation rate drop, a new competitor appearing, citations from a particular domain turning negative? Instead of clicking through filtered views to figure out why, send the chart, drawer, or object directly to Geo and ask &quot;what&#39;s behind this?&quot;. Geo pulls the relevant slice, summarizes it, and points at the underlying conversations.</p>
+<p>See <a href="send-to-geo.html">Send to Geo</a> for the full list of surfaces that support this.</p>
+<h3>Report</h3>
+<p>Geo composes briefings on demand:</p>
+<ul>
+<li>&quot;Give me a one-paragraph executive summary of our GEO performance for the last 30 days.&quot;</li>
+<li>&quot;List the top five competitor mentions in Introspector topics this quarter.&quot;</li>
+<li>&quot;Summarize sentiment trends by region for the last month.&quot;</li>
+</ul>
+<p>Useful for stakeholder updates, board decks, or weekly stand-ups — without manually assembling the numbers.</p>
+<h3>Get Recommendations</h3>
+<p>Geo can suggest <strong>actions</strong>, not just describe the data:</p>
+<ul>
+<li>what content to create</li>
+<li>which citation sources to engage</li>
+<li>which topics to add or refine</li>
+<li>how to counter a competitor&#39;s strength</li>
+</ul>
+<p>Recommendations are grounded in your brand&#39;s actual data, not generic best practice.</p>
+<h3>Run Cross-Feature Workflows</h3>
+<p>Geo is the connective tissue between dashboards, competitive analysis, and content production. A common flow:</p>
+<ol>
+<li>Investigate a competitor in the Competitors view</li>
+<li>Send that competitor to Geo</li>
+<li>Ask &quot;what SWOT perceptions show their strengths?&quot;</li>
+<li>Ask &quot;draft a brief that counters their top strength&quot;</li>
+<li>Hand the brief off to the Content Hub</li>
+</ol>
+<p>You move from noticing something to producing a deliverable inside a single conversation.</p>
+<hr />
+<h2>How Geo Works</h2>
+<p>The platform&#39;s data layer — every read endpoint that powers a chart or drawer — is exposed to the assistant as a set of <strong>tools</strong>. Geo decides which tools to call to answer a given question, runs them with your account&#39;s own permissions, and synthesizes the result in chat.</p>
+<p>You see both the answer <strong>and</strong> the tool calls Geo made, so every response is auditable. See <a href="sessions-and-history.html">Sessions and History</a> for how the tool-call trace is exposed.</p>
+<p>Within a conversation, Geo <strong>replies in a single, consistent language</strong> — once a thread is underway, every answer stays in the same language, so a briefing never switches mid-thread.</p>
+<h3>What Geo Knows About Your Brand</h3>
+<p>Beyond the per-chart data layer, Geo&#39;s context now includes your brand&#39;s <strong>AI Perception Summary</strong> — the overall AI-generated narrative of how your brand is perceived. This means you can ask Geo about your brand&#39;s perception at the highest level, not just metric by metric:</p>
+<ul>
+<li>&quot;How is our brand perceived overall by AI right now?&quot;</li>
+<li>&quot;What&#39;s the headline of our AI perception, and what&#39;s dragging it down?&quot;</li>
+</ul>
+<p>See <a href="../insights/ai-perception-summary.html">AI Perception Summary</a> for the underlying narrative Geo draws on.</p>
+<h3>A Growing Toolset</h3>
+<p>Geo&#39;s tools keep expanding. In addition to the existing data tools, Geo can now also work with:</p>
+<ul>
+<li><strong>CDN log analysis</strong> — surface log clusters and the AI-crawler breakdown, so you can ask how AI crawlers are actually reaching your site. See <a href="../integrations/cdn-log-integration.html">CDN Log Integration</a>.</li>
+<li><strong>Recycle Bin operations</strong> — restore deleted topics and scenarios directly from a conversation.</li>
+</ul>
+<hr />
+<h2>Where Geo Lives</h2>
+<p>Geo is available throughout the dashboard:</p>
+<ul>
+<li>directly via the assistant panel</li>
+<li>as a <strong>Send to Geo</strong> action on virtually every meaningful surface — topic drawer, scenario drawer, conversations page, competitors-by-LLM view, overview, SWOT, perceptions, citations, and the competitor details drawer</li>
+<li>as an <strong>Ask Geo</strong> card surfaced alongside data views, with starter prompts for common questions</li>
+</ul>
+<hr />
+<h2>Using Geo Outside the Dashboard (MCP)</h2>
+<p>Geo is also exposed over <strong>MCP</strong> (Model Context Protocol) with OAuth.</p>
+<p>This means you can connect Geo to MCP-compatible clients you already use — for example, <strong>Claude Desktop</strong> or <strong>Claude Code</strong> — and query your Genezio brand data from outside the dashboard. The same tools (read and action) are available; the same permissions apply.</p>
+<p>Useful when you want to keep Geo in the flow of work you&#39;re already doing in your own AI tooling.</p>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="send-to-geo.html">Send to Geo</a></li>
+<li><a href="sessions-and-history.html">Sessions and History</a></li>
+<li><a href="actions-geo-can-take.html">Actions Geo Can Take</a></li>
+<li><a href="../insights/swot-analysis.html">Insights -&gt; SWOT Analysis</a></li>
+<li><a href="../content-hub/briefs.html">Content Hub -&gt; Briefs</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/geo-assistant/send-to-geo.html
+++ b/new-landing/public/docs/geo-assistant/send-to-geo.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Send to Geo | Genezio Docs</title>
+  <meta name="description" content="Send to Geo in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="geo-assistant.html">Geo Assistant</a></li><li><a class="active" href="send-to-geo.html">Send to Geo</a></li><li><a class="" href="sessions-and-history.html">Sessions and History</a></li><li><a class="" href="actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Send to Geo</h1>
+<p><strong>Send to Geo</strong> is an action available on most data surfaces in the Genezio dashboard. Clicking it hands the current object — a topic, a scenario, a competitor, a citation, a SWOT entry, a perception — to the Geo Assistant with its full context attached.</p>
+<p>You can then ask follow-up questions about that specific object without re-explaining what you&#39;re looking at.</p>
+<hr />
+<h2>Why It Exists</h2>
+<p>Investigating something in the dashboard usually starts with noticing it on a chart or in a drawer. Before <strong>Send to Geo</strong>, the path to a question was:</p>
+<ol>
+<li>See something interesting on a chart</li>
+<li>Open the Geo Assistant</li>
+<li>Re-describe what you&#39;re looking at, in words</li>
+<li>Hope Geo finds the right slice of data</li>
+</ol>
+<p><strong>Send to Geo</strong> collapses that into a single click. The assistant picks up the exact object you were looking at — that competitor, that scenario, that citation source — and you can immediately ask:</p>
+<ul>
+<li>&quot;why is this happening?&quot;</li>
+<li>&quot;what should I do about it?&quot;</li>
+<li>&quot;compare this to last month&quot;</li>
+<li>&quot;show me the conversations behind this number&quot;</li>
+</ul>
+<p>It shortens the path from noticing something in a chart to deciding what to do about it.</p>
+<hr />
+<h2>Where Send to Geo Is Available</h2>
+<p>The action is on virtually every meaningful surface in the dashboard, including:</p>
+<ul>
+<li><strong>Topic drawer</strong> — send a specific topic to investigate performance, citations, or competitors within it</li>
+<li><strong>Scenario drawer</strong> — send a scenario to dig into how it performs across LLMs</li>
+<li><strong>Conversations page</strong> — send a specific conversation for explanation or comparison</li>
+<li><strong>Competitors-by-LLM view</strong> — send a competitor&#39;s behavior on a specific engine</li>
+<li><strong>Competitor details drawer</strong> — send a competitor&#39;s full profile for SWOT, share-of-voice, or counter-strategy questions</li>
+<li><strong>Overview</strong> — send the high-level performance snapshot for a summary or trend explanation</li>
+<li><strong>SWOT</strong> — send a SWOT entry (yours or a competitor&#39;s) to explore the underlying perceptions</li>
+<li><strong>Perceptions</strong> — send an extracted perception for sentiment, source, or context analysis</li>
+<li><strong>Citations</strong> — send a citation source to explore which conversations it appears in and what it says</li>
+</ul>
+<p>Anywhere you see a meaningful object on screen, look for the <strong>Send to Geo</strong> action.</p>
+<hr />
+<h2>What Happens When You Send Something</h2>
+<ol>
+<li>You click <strong>Send to Geo</strong> on the object.</li>
+<li>Geo opens (or comes to the foreground) with the object attached as context.</li>
+<li>Geo acknowledges what it received — for example, &quot;I&#39;m looking at the <em>CRM for startups</em> topic for the last 30 days.&quot;</li>
+<li>You type your follow-up question. Geo answers grounded in that object.</li>
+</ol>
+<p>The attached context stays with the conversation. You can keep asking questions about the same object across multiple turns without re-attaching it.</p>
+<hr />
+<h2>Typical Workflows</h2>
+<p><strong>Diagnose a drop.</strong> On the Overview, your recommendation rate drops on ChatGPT. Click <strong>Send to Geo</strong> on the chart, ask &quot;what&#39;s behind this drop?&quot; — Geo pulls the underlying conversations and explains.</p>
+<p><strong>Counter a competitor.</strong> In the competitor details drawer, click <strong>Send to Geo</strong>, ask &quot;what are their top three strengths in SWOT, and how do I counter them?&quot; — Geo answers, then you can ask it to &quot;draft a brief that addresses the top strength.&quot;</p>
+<p><strong>Audit a citation source.</strong> On the Citations view, send a domain to Geo and ask &quot;what does this source say about us versus competitors?&quot; — Geo summarizes the perceptions extracted from conversations that cite it.</p>
+<p><strong>Explain a scenario.</strong> From the Scenario drawer, send a scenario and ask &quot;which LLM performs worst on this and why?&quot; — Geo cross-references conversations across engines.</p>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="geo-assistant.html">Geo Assistant</a></li>
+<li><a href="sessions-and-history.html">Sessions and History</a></li>
+<li><a href="../insights/swot-analysis.html">Insights -&gt; SWOT Analysis</a></li>
+<li><a href="../core-concepts/competitors.html">Core Concepts -&gt; Competitors</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/geo-assistant/sessions-and-history.html
+++ b/new-landing/public/docs/geo-assistant/sessions-and-history.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sessions and History | Genezio Docs</title>
+  <meta name="description" content="Sessions and History in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="geo-assistant.html">Geo Assistant</a></li><li><a class="" href="send-to-geo.html">Send to Geo</a></li><li><a class="active" href="sessions-and-history.html">Sessions and History</a></li><li><a class="" href="actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Sessions and History</h1>
+<p>The Geo Assistant supports <strong>multiple chat sessions</strong> with a real history sidebar. You can switch between conversations, come back to one later, and inspect the tool calls Geo made to produce each answer.</p>
+<p>This turns Geo from a one-shot chat into a persistent workspace.</p>
+<hr />
+<h2>Multiple Sessions</h2>
+<p>You can keep several Geo sessions running in parallel. Each session is independent — its own conversation history, its own attached context (from any <strong>Send to Geo</strong> actions), and its own thread of follow-up questions.</p>
+<p>Common patterns:</p>
+<ul>
+<li>a <strong>&quot;Competitor X investigation&quot;</strong> session you return to as new data comes in</li>
+<li>a <strong>&quot;Q2 content planning&quot;</strong> session that grows over weeks of asking Geo for brief ideas</li>
+<li>a <strong>&quot;Fix our Perplexity gap&quot;</strong> session focused on a single engine</li>
+<li>short-lived sessions for one-off questions (&quot;summarize last week&#39;s performance&quot;)</li>
+</ul>
+<p>You can switch between sessions at any time and pick up either thread on any day.</p>
+<hr />
+<h2>The History Sidebar</h2>
+<p>The history sidebar lists every session associated with your account. From it you can:</p>
+<ul>
+<li>open any previous session and continue the conversation</li>
+<li>rename a session so it&#39;s easy to find later</li>
+<li>delete sessions you no longer need</li>
+</ul>
+<p>Each session keeps its full message history, attached context, and tool-call trace, so returning to a session weeks later gives you the same view you left.</p>
+<hr />
+<h2>Tool-Call Traces</h2>
+<p>Every answer Geo produces is grounded in calls it makes against the platform&#39;s data — the same read endpoints that power the dashboard&#39;s charts and drawers. Geo shows you the <strong>tool calls</strong> it made for each answer.</p>
+<p>You can see:</p>
+<ul>
+<li>which tool was called (for example, a specific metric lookup or conversation fetch)</li>
+<li>what parameters it was called with (the topic, the date range, the filter)</li>
+<li>what came back</li>
+</ul>
+<p>This makes Geo&#39;s answers <strong>auditable</strong>. Instead of trusting an opaque response, you can verify exactly which dashboard query produced it. If Geo claims your share of voice dropped 12% on a given topic, you can see the underlying call and confirm the number.</p>
+<hr />
+<h2>Why It Matters</h2>
+<p>Sessions and tool-call traces change how teams use the assistant:</p>
+<ul>
+<li><strong>Persistent investigations</strong> — long-running threads survive across days and team members, instead of being lost when the tab closes.</li>
+<li><strong>Trust</strong> — a visible tool-call trace lets you check Geo&#39;s work. The assistant becomes a colleague whose reasoning you can inspect, not a black-box chatbot.</li>
+<li><strong>Parallel work</strong> — keeping a competitor investigation, a content plan, and a stakeholder-report session open at the same time lets you treat Geo as a workspace, not a search bar.</li>
+</ul>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="geo-assistant.html">Geo Assistant</a></li>
+<li><a href="send-to-geo.html">Send to Geo</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/getting-started/create-scenarios.html
+++ b/new-landing/public/docs/getting-started/create-scenarios.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Create Scenarios | Genezio Docs</title>
+  <meta name="description" content="Create Scenarios in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="active" href="setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="setup-guide.html">Setup Guide</a></li><li><a class="" href="sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="describe-your-brand.html">Describe Your Brand</a></li><li><a class="active" href="create-scenarios.html">Create Scenarios</a></li><li><a class="" href="generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="topic-tags.html">Topic Tags</a></li><li><a class="" href="your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Create Scenarios</h1>
+<p>Scenarios are how Genezio simulates real buyer questions. Good scenarios sound like the questions your customers actually ask AI assistants, including the constraints and follow-ups that influence which brands get recommended.</p>
+<p>For each topic, Genezio generates scenarios across different intents, from open discovery questions to direct recommendation requests and brand-specific questions. You can review and edit these before confirming them.</p>
+<hr />
+<h2>Writing Effective Scenarios</h2>
+<ul>
+<li><strong>Sound like a real buyer</strong> — draft prompts from real customer questions, call transcripts, and FAQs.</li>
+<li><strong>Include constraints</strong> — team size, budget, location, or technology stack all shape recommendations.</li>
+<li><strong>Cover branded and non-branded entry points</strong> — measure both how you are discovered and how you are evaluated by name.</li>
+<li><strong>Add follow-up turns</strong> — multi-turn paths reveal deeper model reasoning.</li>
+</ul>
+<hr />
+<h2>Changing a Scenario Type Later</h2>
+<p>You are not locked into your first choice. An existing scenario can be <strong>converted to another type</strong> later (for example, from a <strong>Prompter</strong> into a <strong>Recommender</strong>), and you choose the persona to use for the converted scenario.</p>
+<p>To learn more about the available scenario types and when to use each, see <a href="../core-concepts/scenarios.html">Scenarios</a>.</p>
+<hr />
+<h2>Next Steps</h2>
+<p>After confirming your scenarios, continue with:</p>
+<ul>
+<li><a href="./run-your-first-conversations.html">Run Your First Conversations</a></li>
+<li><a href="../core-concepts/scenarios.html">Scenarios</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/getting-started/customizing-your-dashboard.html
+++ b/new-landing/public/docs/getting-started/customizing-your-dashboard.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Customizing Your Dashboard | Genezio Docs</title>
+  <meta name="description" content="Customizing Your Dashboard in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="active" href="setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="setup-guide.html">Setup Guide</a></li><li><a class="" href="sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="create-scenarios.html">Create Scenarios</a></li><li><a class="" href="generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="active" href="customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="topic-tags.html">Topic Tags</a></li><li><a class="" href="your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Customizing Your Dashboard</h1>
+<p>The Genezio dashboard is broad on purpose — it surfaces visibility, recommendations, citations, perceptions, competitors, SOV, and more. But not every brand cares about all of those, all the time.</p>
+<p><strong>Dashboard Components</strong> lets each brand strip the dashboard down to what actually matters for that brand, by hiding the charts, tables, and panels that aren&#39;t being used.</p>
+<hr />
+<h2>Why Customize the Dashboard</h2>
+<p>Different brands live in different parts of the platform.</p>
+<ul>
+<li>A consumer brand might spend most of its time in <strong>Citations</strong> and <strong>Recommender</strong> results.</li>
+<li>A B2B brand might focus on <strong>Introspector</strong> and <strong>Share of Voice</strong>.</li>
+<li>A regulated brand might care most about <strong>Perceptions</strong> and the <strong>Grounded</strong> badge.</li>
+<li>An agency managing multiple clients will want different defaults per client.</li>
+</ul>
+<p>Showing every section to every brand creates noise. Hiding the ones that don&#39;t apply makes the dashboard easier to scan and the daily workflow tighter.</p>
+<hr />
+<h2>How It Works</h2>
+<p>Each <strong>dashboard component</strong> — a chart, a table, a panel — can be toggled on or off independently.</p>
+<p>A hidden component is genuinely removed from the page:</p>
+<ul>
+<li>it doesn&#39;t render</li>
+<li>it doesn&#39;t make its API calls</li>
+<li>the page loads faster as a result</li>
+</ul>
+<p>This is real performance, not just visual hiding. The fewer components you have on, the lighter the dashboard becomes.</p>
+<hr />
+<h2>Where to Configure It</h2>
+<p>Dashboard component visibility is configured in <strong>Brand Settings → Dashboard Components</strong>.</p>
+<p>For each component, you choose whether it&#39;s shown or hidden for the brand. The change applies to everyone who works on that brand — it&#39;s the brand&#39;s default dashboard shape.</p>
+<h3>Per-User Overrides</h3>
+<p>The brand-level configuration is a <strong>default</strong>, not a hard rule. Individual users can override what they personally see — turning a component back on if it&#39;s hidden by default, or off if it&#39;s shown.</p>
+<p>This gives you the right of both ends:</p>
+<ul>
+<li><strong>brand owners</strong> can set a sensible default so every team member sees the same focused dashboard</li>
+<li><strong>individual users</strong> can adjust their own view when they need to see something specific without changing the default for everyone</li>
+</ul>
+<hr />
+<h2>Getting Started</h2>
+<p>A reasonable starting point:</p>
+<ol>
+<li>Open the dashboard and look at what you actually use over the course of a week.</li>
+<li>Go to <strong>Brand Settings → Dashboard Components</strong> and hide the panels you&#39;ve never opened.</li>
+<li>Leave a few in the &quot;maybe&quot; category visible for a couple more weeks before deciding.</li>
+<li>Re-tune any time the brand&#39;s priorities shift.</li>
+</ol>
+<p>You can always turn things back on. The customization is reversible, so there&#39;s no risk to being aggressive about hiding things you don&#39;t use today.</p>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="setup-guide.html">Setup Guide</a></li>
+<li><a href="your-first-week.html">Your First Week</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/getting-started/describe-your-brand.html
+++ b/new-landing/public/docs/getting-started/describe-your-brand.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Describe Your Brand | Genezio Docs</title>
+  <meta name="description" content="Describe Your Brand in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="active" href="setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="setup-guide.html">Setup Guide</a></li><li><a class="" href="sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="active" href="describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="create-scenarios.html">Create Scenarios</a></li><li><a class="" href="generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="topic-tags.html">Topic Tags</a></li><li><a class="" href="your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Describe Your Brand</h1>
+<p>A precise brand description helps Genezio represent your brand correctly in AI conversations. It improves the quality of generated scenarios and ensures AI systems evaluate your brand in the right context.</p>
+<p>When Genezio first generates a description for you, it summarizes what your brand does, the category it belongs to, and the type of customers it serves. You review this description, edit it where needed, and confirm it.</p>
+<hr />
+<h2>What a Good Description Captures</h2>
+<ul>
+<li><strong>Core positioning</strong> — what your brand does, in clear and non-promotional language.</li>
+<li><strong>Category and use cases</strong> — the space you compete in and the problems you solve.</li>
+<li><strong>Differentiators</strong> — what sets you apart in comparisons.</li>
+<li><strong>Honest constraints</strong> — price tier, region, and integrations.</li>
+</ul>
+<hr />
+<h2>Set Your Brand Language</h2>
+<p>You can set a <strong>brand language</strong> for your brand. This language is used to generate reports and conversations, so the way your brand is described and measured matches the market you serve.</p>
+<hr />
+<h2>Next Steps</h2>
+<p>Once your brand description is confirmed, continue with:</p>
+<ul>
+<li><a href="./define-topics.html">Define Topics</a></li>
+<li><a href="./create-scenarios.html">Create Scenarios</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/getting-started/generating-personas-from-documents.html
+++ b/new-landing/public/docs/getting-started/generating-personas-from-documents.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Generating Personas from Documents | Genezio Docs</title>
+  <meta name="description" content="Generating Personas from Documents in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="active" href="setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="setup-guide.html">Setup Guide</a></li><li><a class="" href="sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="create-scenarios.html">Create Scenarios</a></li><li><a class="active" href="generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="topic-tags.html">Topic Tags</a></li><li><a class="" href="your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Generating Personas from Documents</h1>
+<p>If you already have persona research documented somewhere, the fastest way to get a persona into Genezio is to <strong>upload that document</strong>. The platform reads it and generates the persona for you.</p>
+<p>This is the path most new teams should take. Building a persona from a real document — one that already encodes how your business thinks about a customer segment — is dramatically faster than filling out an empty form, and the resulting persona is usually better.</p>
+<hr />
+<h2>Why Start From a Document</h2>
+<p>Personas are the single biggest lever on result quality in Genezio. A weak persona produces weak conversations, which produce weak insights. A strong persona — grounded in real audience knowledge — sets the platform up to do its best work.</p>
+<p>Most teams <strong>already have</strong> that audience knowledge written down. It just lives outside Genezio:</p>
+<ul>
+<li>a buyer-persona document from the brand or research team</li>
+<li>an internal customer-research deck</li>
+<li>a job description for the role your product serves</li>
+<li>customer-success notes, sales discovery summaries, ICP one-pagers, ideal-customer write-ups</li>
+</ul>
+<p>Document import lets you bring that work in directly, instead of recreating it from scratch in a form.</p>
+<hr />
+<h2>What You Get</h2>
+<p>Upload a document and Genezio generates a complete persona for the brand: name, role, country, city, language, and the supporting context that drives how conversations are framed.</p>
+<p>The persona is <strong>saved immediately</strong> — it&#39;s a real, usable persona for the brand from the moment generation finishes. You can edit it after the fact the same way you&#39;d edit any other persona, in case anything needs adjustment.</p>
+<p>Each upload produces <strong>one persona</strong>. If your source document describes several distinct personas, upload it separately for each one (or split the document beforehand).</p>
+<hr />
+<h2>When to Use This vs. the Form</h2>
+<table>
+<thead><tr><th style="text-align:left">Situation</th><th style="text-align:left">Recommended path</th></tr></thead>
+<tbody>
+<tr><td style="text-align:left">You already have a persona doc, research deck, or job description</td><td style="text-align:left"><strong>Upload the document</strong></td></tr>
+<tr><td style="text-align:left">You have ICP notes living in a Notion page, sales playbook, or any other document</td><td style="text-align:left"><strong>Upload the document</strong></td></tr>
+<tr><td style="text-align:left">You&#39;re starting from a blank slate with no persona research</td><td style="text-align:left">Fill out the form, or write a short doc first and then upload it</td></tr>
+<tr><td style="text-align:left">You want quick variation on an existing persona</td><td style="text-align:left">Clone the existing persona and edit</td></tr>
+</tbody>
+</table>
+<p>If you&#39;re not sure your document is &quot;good enough&quot; to use, upload it anyway. Generation is fast, the result is editable, and starting from a real document usually beats starting from nothing.</p>
+<hr />
+<h2>Tips for a Good Result</h2>
+<ul>
+<li><strong>Use the most specific, current document you have.</strong> Stale documents produce stale personas.</li>
+<li><strong>Include role and context, not just demographics.</strong> A persona that knows the buyer&#39;s job-to-be-done generates better conversations than one that only knows their age and location.</li>
+<li><strong>If the source describes multiple audiences, split first.</strong> You&#39;ll get a sharper persona by uploading the relevant section than the whole thing.</li>
+<li><strong>Review the persona after generation.</strong> It&#39;s editable for a reason — small tweaks (a clearer name, a more specific city, a refined description) usually pay off in the conversations the platform runs.</li>
+</ul>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="../core-concepts/personas.html">Core Concepts -&gt; Personas</a></li>
+<li><a href="setup-guide.html">Setup Guide</a></li>
+<li><a href="your-first-week.html">Your First Week</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/getting-started/setup-guide.html
+++ b/new-landing/public/docs/getting-started/setup-guide.html
@@ -1,0 +1,195 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Setup Guide | Genezio Docs</title>
+  <meta name="description" content="Setup Guide in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="active" href="setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="active" href="setup-guide.html">Setup Guide</a></li><li><a class="" href="sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="create-scenarios.html">Create Scenarios</a></li><li><a class="" href="generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="topic-tags.html">Topic Tags</a></li><li><a class="" href="your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Getting Started</h1>
+<p>This guide walks you through the initial setup process in Genezio. The setup is designed to quickly create the data needed to measure your brand&#39;s AI Recommendations and Visibility across AI systems such as ChatGPT, Claude, Gemini, and Perplexity.</p>
+<p>The process takes only a few minutes and results in a complete set of topics and scenarios that Genezio will use to run AI conversations.</p>
+<hr />
+<h2>Step 1: Create Your Account</h2>
+<p>To begin, go to:</p>
+<p><a href="https://app.genezio.ai/sign-up">https://app.genezio.ai/sign-up</a></p>
+<p>During signup you will be asked to provide a few basic details about your brand:</p>
+<ul>
+<li><strong>Brand name</strong></li>
+<li><strong>Website URL</strong></li>
+<li><strong>Main customer country</strong></li>
+<li><strong>Main customer language</strong></li>
+</ul>
+<p>This information allows Genezio to understand the market and audience your brand serves.</p>
+<hr />
+<h2>Step 2: Confirm Your Brand Description</h2>
+<p>After the initial information is submitted, Genezio automatically generates a <strong>brand description</strong>.</p>
+<p>This description summarizes:</p>
+<ul>
+<li>what your brand does</li>
+<li>the category it belongs to</li>
+<li>the type of customers it serves</li>
+</ul>
+<p>The generated description is shown to you for review.</p>
+<p>You can:</p>
+<ul>
+<li>confirm it if it is correct</li>
+<li>edit it if adjustments are needed</li>
+</ul>
+<p>Confirming this description ensures that Genezio understands how your brand should be represented in AI conversations.</p>
+<hr />
+<h2>Step 3: Confirm the Customer Profile</h2>
+<p>Next, Genezio generates a <strong>customer profile description</strong> based on your brand and market.</p>
+<p>This profile represents the typical person who might search for solutions like yours using an AI assistant.</p>
+<p>The description may include details such as:</p>
+<ul>
+<li>the type of user</li>
+<li>their goals</li>
+<li>the problems they are trying to solve</li>
+</ul>
+<p>You can review and edit this description before confirming it.</p>
+<p>This profile helps Genezio simulate realistic user questions in later steps.</p>
+<hr />
+<h2>Step 4: Confirm Topics</h2>
+<p>Once the customer profile is confirmed, Genezio generates a set of <strong>topics</strong>.</p>
+<p>Topics represent the areas where users might ask AI systems questions related to your brand or category.</p>
+<p>Examples of topics might include:</p>
+<ul>
+<li>CRM for startups</li>
+<li>sales automation tools</li>
+<li>marketing automation platforms</li>
+</ul>
+<p>You can review, edit, or remove topics before confirming them.</p>
+<p>Topics determine the areas where Genezio will measure AI Recommendations and Visibility.</p>
+<hr />
+<h2>Step 5: Confirm Scenarios</h2>
+<p>For each topic, Genezio generates setup elements used to simulate different user intents.</p>
+<p>In practice, there is an important distinction between Genezio Agent types.</p>
+<h3>Prompter Agent</h3>
+<p>The <strong>Prompter Agent</strong> is an agent type where the text is sent to the answer engine as a direct prompt.</p>
+<p>It is not scenario-based like the other agent types.</p>
+<p>Example:</p>
+<pre><code>What CRM should a startup use?</code></pre>
+<h3>Recommender Agent</h3>
+<p>Scenario-based agent type focused on direct recommendation requests.</p>
+<p>Example:</p>
+<pre><code>Recommend CRM tools for early-stage startups.</code></pre>
+<h3>Introspector Agent</h3>
+<p>Scenario-based agent type focused on understanding a specific brand.</p>
+<p>Example:</p>
+<pre><code>What is HubSpot used for?</code></pre>
+<p>You can review and edit these scenarios before confirming them.</p>
+<p>Genezio also supports <strong>comparer scenarios</strong> (for example, comparing two brands), but these are typically added later during deeper analysis.</p>
+<hr />
+<h2>Step 6: Start Your Free Trial</h2>
+<p>After confirming your scenarios, your <strong>free trial begins</strong>.</p>
+<p>At this point Genezio automatically starts running conversations with AI systems in the background.</p>
+<p>These conversations simulate users asking the scenarios you confirmed.</p>
+<hr />
+<h2>Step 7: Conversations Run in Real Time</h2>
+<p>As conversations are executed, you can watch them run in real time inside the Genezio interface.</p>
+<p>For each conversation, Genezio:</p>
+<ul>
+<li>sends the scenario prompt to the AI system</li>
+<li>captures the response</li>
+<li>extracts mentions of brands</li>
+<li>detects citations and sources</li>
+<li>extracts and evaluates perceptions (claims) for accuracy</li>
+</ul>
+<p>This process builds the dataset used to calculate AI Recommendations and Visibility.</p>
+<hr />
+<h2>Step 8: Explore Your Brand Overview</h2>
+<p>Once conversations begin running, you are taken to your <strong>Brand Overview</strong> page.</p>
+<p>This dashboard provides a high-level view of your AI Recommendations and Visibility.</p>
+<p>From here you can:</p>
+<ul>
+<li>see how often your brand appears in AI answers</li>
+<li>view competitors appearing in the same conversations</li>
+<li>explore which sources influence AI responses</li>
+<li>analyze visibility across different topics</li>
+</ul>
+<p>You can then dive deeper into specific conversations, topics, or insights to better understand how AI systems represent your brand.</p>
+<hr />
+<h2>Managing Your Setup</h2>
+<p>As you build and refine your setup, Genezio includes a few quality-of-life capabilities that make the process safer and easier to follow:</p>
+<ul>
+<li><strong>Recycle Bin</strong> — deleted topics and scenarios are not lost immediately. If you remove something by mistake, you can restore it from the Recycle Bin.</li>
+<li><strong>Brand language</strong> — you can set your brand&#39;s language during setup. Reports such as <strong>perceptions</strong>, <strong>SWOT</strong>, and <strong>AI insights</strong> are then generated in that language.</li>
+<li><strong>Predictable order and auto-scroll</strong> — newly added topics and scenarios appear in a predictable order, and the view automatically scrolls to them, so you can immediately see what you just created.</li>
+</ul>
+<hr />
+<h2>Next Steps</h2>
+<p>To better understand the concepts behind these results, see:</p>
+<ul>
+<li><a href="./introduction/what-kpis-are-we-measuring.html">Introduction -&gt; What KPIs Are We Measuring</a></li>
+<li><a href="./introduction/how-llm-search-works.html">Introduction -&gt; How LLM Search Works</a></li>
+<li><a href="./core-concepts/topics.html">Core Concepts -&gt; Topics</a></li>
+</ul>
+<p>These pages explain the underlying concepts used throughout Genezio.</p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/getting-started/sign-in-and-sso-options.html
+++ b/new-landing/public/docs/getting-started/sign-in-and-sso-options.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sign-in and SSO Options | Genezio Docs</title>
+  <meta name="description" content="Sign-in and SSO Options in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="active" href="setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="setup-guide.html">Setup Guide</a></li><li><a class="active" href="sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="create-scenarios.html">Create Scenarios</a></li><li><a class="" href="generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="topic-tags.html">Topic Tags</a></li><li><a class="" href="your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Sign-in and SSO Options</h1>
+<p>Genezio offers several ways to <strong>sign in</strong>, so you can use the method that fits how your team already works — a simple email and password, your Microsoft account, or your organization&#39;s single sign-on.</p>
+<p>This page walks through the available options, how to sign up, how to join a team you&#39;ve been invited to, and what enterprise SSO looks like.</p>
+<hr />
+<h2>Available Sign-in Methods</h2>
+<ul>
+<li><strong>Email and password</strong> — Create an account with your email address and a password. New accounts go through an email verification step before they&#39;re active.</li>
+<li><strong>Microsoft / Entra</strong> — Sign in with your Microsoft (Entra) account. This works on mobile as well as desktop.</li>
+<li><strong>Enterprise SSO (SAML)</strong> — For organizations that want everyone to sign in through their own identity provider. See the section below.</li>
+</ul>
+<p>The sign-in, sign-up, verification, and invite pages share a clean, consistent layout with provider and LLM icons so the right option is easy to spot.</p>
+<hr />
+<h2>How to Sign Up</h2>
+<ol>
+<li>Enter your details — your name, email address, and a password.</li>
+<li>Accept the legal terms (the disclaimers shown on the sign-up page).</li>
+<li>Choose your marketing-email preference — this is an opt-in, so it&#39;s entirely up to you.</li>
+<li>Verify your email — Genezio sends you a verification message; click the link to confirm your address and activate your account.</li>
+</ol>
+<p>Once your email is verified, you can sign in and start setting up your brand.</p>
+<hr />
+<h2>How to Accept a Team Invite</h2>
+<p>If a colleague has invited you to an existing team, you&#39;ll receive an invitation by email.</p>
+<ol>
+<li>Open the invitation email and follow the accept-invite link.</li>
+<li>Complete the short sign-up step if you don&#39;t already have an account.</li>
+<li>You&#39;ll join the team and land in the shared workspace, ready to go.</li>
+</ol>
+<hr />
+<h2>Enterprise SSO (SAML)</h2>
+<p>For organizations that prefer centralized access, Genezio supports <strong>single sign-on (SSO) via SAML</strong>, powered by Keycloak. This lets your people sign in through your company&#39;s existing identity provider, using the credentials and policies you already manage.</p>
+<p>Enterprise SSO is set up together with the Genezio team. You provide the details for your identity provider, the connection is configured on both sides, and from then on your users sign in through your organization&#39;s normal login. If single sign-on is a requirement for your organization, reach out to the Genezio team to get it configured.</p>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="create-an-account.html">Create an Account</a></li>
+<li><a href="../security/privacy.html">Privacy</a></li>
+<li><a href="../security/compliance.html">Compliance</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/getting-started/topic-tags.html
+++ b/new-landing/public/docs/getting-started/topic-tags.html
@@ -1,0 +1,136 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Topic Tags | Genezio Docs</title>
+  <meta name="description" content="Topic Tags in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="active" href="setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="setup-guide.html">Setup Guide</a></li><li><a class="" href="sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="create-scenarios.html">Create Scenarios</a></li><li><a class="" href="generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="active" href="topic-tags.html">Topic Tags</a></li><li><a class="" href="your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Topic Tags</h1>
+<p><strong>Topic Tags</strong> are user-defined labels you attach to topics to keep them organized.</p>
+<p>A few weeks into a serious deployment, most brands accumulate a lot of topics — 40, 60, sometimes 100+ — across content pillars, product lines, customer segments, regions, and tracking purposes. Without organization, the topics page becomes a flat list nobody scans. Tags are the layer that fixes that.</p>
+<hr />
+<h2>What Tags Are</h2>
+<p>Each tag has a <strong>name</strong> and a <strong>color</strong> you pick. Topics can carry <strong>multiple tags</strong>, so the same topic can belong to several views at once (for example, a topic about pricing for SMB customers might be tagged both <em>Pricing</em> and <em>SMB</em>).</p>
+<p>Tags are managed <strong>per brand</strong>. Each brand has its own tag library, so taxonomies don&#39;t leak across brands — useful for agencies and multi-brand teams where each brand has its own organizing logic.</p>
+<p>There&#39;s no prescribed taxonomy. You apply the structure that fits how your team thinks about the topics you track — not one we picked for you.</p>
+<hr />
+<h2>When to Use Them</h2>
+<p>A few common taxonomies brands settle on:</p>
+<h3>Content Pillars</h3>
+<p>Tag topics by the pillar they belong to — <em>Solutions</em>, <em>Use Cases</em>, <em>Platform</em>, <em>Industries</em>. Helpful when content planning and brand tracking share the same vocabulary, and you want to see how each pillar is performing in answer engines.</p>
+<h3>Product Lines or SKUs</h3>
+<p>For multi-product companies, tag each topic by which product it relates to — <em>CRM</em>, <em>Marketing Hub</em>, <em>Service Hub</em>. Lets you slice the dashboard product by product, which matters when each line has its own owner.</p>
+<h3>Customer Segments</h3>
+<p>Tag by audience — <em>SMB</em>, <em>Mid-market</em>, <em>Enterprise</em>. Useful when your topics span the full funnel and different teams own different segments.</p>
+<p>You can also combine taxonomies. A single topic might carry <em>Pricing</em> (pillar), <em>CRM</em> (product), and <em>SMB</em> (segment) — and show up under each view when you filter.</p>
+<hr />
+<h2>How to Create and Apply Tags</h2>
+<p>Tags are created in the <strong>tag library</strong> before they can be applied to topics. This keeps the library clean and color-coordinated — no ad-hoc duplicates.</p>
+<h3>Create a Tag</h3>
+<ol>
+<li>Open the tag library for the brand.</li>
+<li>Click to add a new tag.</li>
+<li>Enter a <strong>name</strong> and pick a <strong>color</strong> from the picker.</li>
+<li>Save it.</li>
+</ol>
+<p>The tag is now available across the brand.</p>
+<h3>Apply Tags to a Topic</h3>
+<p>Open any topic and pick from the tag library to attach one or more tags. Topics can carry as many tags as they need.</p>
+<hr />
+<h2>Filtering by Tag</h2>
+<p>The topics page supports filtering by tag. Pick one or more tags and the list narrows to topics that match.</p>
+<p>Tag filters combine with other filter dimensions (answer engine, persona, time range, and so on) — so you can ask questions like &quot;show me all topics tagged <em>SMB</em> for ChatGPT in the last 30 days&quot; by stacking the filters together.</p>
+<hr />
+<h2>Managing the Tag Library</h2>
+<p>The tag library is where the taxonomy lives, and it needs occasional care:</p>
+<ul>
+<li><strong>Edit</strong> a tag to rename it or change its color</li>
+<li><strong>Delete</strong> a tag that&#39;s no longer used (it&#39;s removed from every topic it was applied to)</li>
+<li><strong>Scope</strong> is always brand-level — tags don&#39;t move between brands</li>
+</ul>
+<p>Treat the library the way you&#39;d treat any taxonomy: prune stale tags, keep names short, and keep the color set legible at a glance.</p>
+<hr />
+<h2>Best Practices</h2>
+<p>A few things that keep tags useful instead of cluttered:</p>
+<ul>
+<li><strong>Start small.</strong> Three to five tags is plenty when you begin. Add more as the need actually shows up — not preemptively.</li>
+<li><strong>One axis at a time.</strong> It&#39;s easier to introduce a pillar taxonomy first, get it stable, and then layer on a segment or product taxonomy later, than to design all three on day one.</li>
+<li><strong>Use color discipline.</strong> Pick distinct colors for tags that belong to different taxonomies (e.g., all pillar tags in one color family, all segment tags in another). This makes the topics page scannable at a glance.</li>
+<li><strong>Retire tags you don&#39;t use.</strong> If a tag hasn&#39;t been filtered on in months, it&#39;s probably noise. Delete it.</li>
+<li><strong>Keep names short.</strong> Tags are visual labels, not sentences. <em>SMB</em>, <em>Pricing</em>, <em>EU</em> read better than <em>Small and Medium Business Customers</em>.</li>
+</ul>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="../core-concepts/topics.html">Core Concepts -&gt; Topics</a></li>
+<li><a href="setup-guide.html">Setup Guide</a></li>
+<li><a href="your-first-week.html">Your First Week</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/getting-started/your-first-week.html
+++ b/new-landing/public/docs/getting-started/your-first-week.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Your First Week | Genezio Docs</title>
+  <meta name="description" content="Your First Week in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="active" href="setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="setup-guide.html">Setup Guide</a></li><li><a class="" href="sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="create-scenarios.html">Create Scenarios</a></li><li><a class="" href="generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="topic-tags.html">Topic Tags</a></li><li><a class="active" href="your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Your First Week with Genezio</h1>
+<p><em>A practical day-by-day guide for Digital Marketing Managers. By the end of your first week, you&#39;ll have your baseline scores, your first competitor analysis, and a prioritized content action list.</em></p>
+<blockquote><p><strong>Before you start:</strong> Have your brand name, top 2–3 competitor names, and a list of 5–10 topics you want to rank for in AI answers ready. Topics should be category-level phrases like &quot;AI visibility platform,&quot; &quot;project management for remote teams,&quot; or &quot;CRM for startups&quot; — not product names.</p></blockquote>
+<hr />
+<h2>Day 1 — Monday: Set Up Your Brand and Baseline</h2>
+<p><em>~2 hours · Goal: first conversations running by end of day</em></p>
+<ul>
+<li class="task-item"><label><input type="checkbox" disabled /> <span><strong>Add your brand</strong> in Genezio. Include your website URL and a short description of what you do. → <em>Core Concepts → Brands</em></span></label></li>
+<li class="task-item"><label><input type="checkbox" disabled /> <span><strong>Add your top 2–3 competitors.</strong> Genezio tracks them in parallel so every score you see already has a comparative layer. → <em>Core Concepts → Competitors</em></span></label></li>
+<li class="task-item"><label><input type="checkbox" disabled /> <span><strong>Create your first 3–5 Topics.</strong> Start narrow — one topic per core use case or buyer persona. You can expand later. → <em>Core Concepts → Topics</em></span></label></li>
+<li class="task-item"><label><input type="checkbox" disabled /> <span><strong>Create 2–3 Scenarios per topic.</strong> Write them as real user questions — the way a buyer would actually phrase it to ChatGPT. Not &quot;CRM features&quot; but &quot;What CRM should a 10-person startup use?&quot; → <em>Running Conversations → Creating Scenarios</em></span></label></li>
+<li class="task-item"><label><input type="checkbox" disabled /> <span><strong>Select your answer engines.</strong> Start with ChatGPT and Perplexity. Add Claude and Gemini once you have the baseline. → <em>Running Conversations → Selecting Answer Engines</em></span></label></li>
+<li class="task-item"><label><input type="checkbox" disabled /> <span><strong>Run your first conversations.</strong> Results typically available within minutes.</span></label></li>
+</ul>
+<p><strong>End of Day 1 deliverable:</strong> First AI Recommendations % and AI Visibility % numbers for your brand and competitors. Initial list of which sources AI is already citing in your category.</p>
+<hr />
+<h2>Day 2 — Tuesday: Read Your Baseline Scores</h2>
+<p><em>~1.5 hours · Goal: understand where you stand and why</em></p>
+<ul>
+<li class="task-item"><label><input type="checkbox" disabled /> <span><strong>Check AI Recommendations % and AI Visibility %</strong> for each topic. Note which topics you score well on and which are gaps.</span></label></li>
+<li class="task-item"><label><input type="checkbox" disabled /> <span><strong>Open Citations.</strong> For each topic where your score is low, look at which URLs AI is citing. Write them down — this list becomes your PR and link-building roadmap.</span></label></li>
+<li class="task-item"><label><input type="checkbox" disabled /> <span><strong>Check Perceptions.</strong> What claims is AI making about your brand? Flag anything outdated, negative, or missing.</span></label></li>
+<li class="task-item"><label><input type="checkbox" disabled /> <span><strong>Compare your scores with competitors.</strong> Note who leads, by how much, and what sources they&#39;re cited from that you aren&#39;t.</span></label></li>
+</ul>
+<blockquote><p><strong>Tip:</strong> Pick the one topic where the gap between you and the top competitor is smallest — that&#39;s your first quick win opportunity.</p></blockquote>
+<p><strong>End of Day 2 deliverable:</strong> Scored list of topics to prioritize. Citation source list (5–10 domains AI trusts in your category). Perception issues flagged.</p>
+<hr />
+<h2>Day 3 — Wednesday: Deep Dive into Actionable Insights</h2>
+<p><em>~1 hour · Goal: let Genezio tell you exactly what to fix</em></p>
+<ul>
+<li class="task-item"><label><input type="checkbox" disabled /> <span><strong>Open Actionable Insights.</strong> Read through all four categories: Growth Opportunities, Critical Visibility Gaps, Citation &amp; Authority Leverage, and Positioning &amp; Structural Optimization. → <em>Actions → Actionable Insights</em></span></label></li>
+<li class="task-item"><label><input type="checkbox" disabled /> <span><strong>Prioritize by impact.</strong> High-priority insights are the ones your competitors are winning right now. Dismiss anything that isn&#39;t actionable for your team.</span></label></li>
+<li class="task-item"><label><input type="checkbox" disabled /> <span><strong>Generate additional insights on demand</strong> for specific topics or scenarios if you want a focused view. You can add custom instructions like &quot;focus on quick wins&quot; or &quot;prioritize opportunities vs. [competitor name].&quot; → <em>Actions → Actionable Insights → Manually Generating Insights</em></span></label></li>
+<li class="task-item"><label><input type="checkbox" disabled /> <span><strong>Map each insight to a content action:</strong> create content / get a citation / fix schema / earn press coverage.</span></label></li>
+</ul>
+<p><strong>End of Day 3 deliverable:</strong> Prioritized list of 5–10 specific actions. Each action mapped to: content type, responsible person, estimated timeline.</p>
+<hr />
+<h2>Day 4 — Thursday: Build Your First Content Brief</h2>
+<p><em>~2 hours · Goal: first Genezio-informed content piece briefed and assigned</em></p>
+<p>Take the highest-priority insight from Day 3 and turn it into a proper content brief:</p>
+<ul>
+<li class="task-item"><label><input type="checkbox" disabled /> <span><strong>Title and target keyword</strong> — use the exact phrase the AI uses in scenarios where you score low.</span></label></li>
+<li class="task-item"><label><input type="checkbox" disabled /> <span><strong>Citation sources to reference</strong> — list 3–5 sources from Genezio&#39;s Citation section for this topic. Your content should reference these domains as external links.</span></label></li>
+<li class="task-item"><label><input type="checkbox" disabled /> <span><strong>Inaccurate claims to correct</strong> — include any AI perceptions about your brand that are incorrect and need to be addressed through better content.</span></label></li>
+<li class="task-item"><label><input type="checkbox" disabled /> <span><strong>Schema markup requirements</strong> — flag if the page needs FAQPage, HowTo, or other schema.</span></label></li>
+<li class="task-item"><label><input type="checkbox" disabled /> <span><strong>Assign and set a re-measurement date</strong> — re-run the relevant Genezio conversations 2–4 weeks after publishing.</span></label></li>
+</ul>
+<p><strong>End of Day 4 deliverable:</strong> One complete content brief assigned. Re-measurement date booked in your calendar.</p>
+<hr />
+<h2>Day 5 — Friday: Set Up Your Monthly Reporting Rhythm</h2>
+<p><em>~1 hour · Goal: AI visibility becomes a permanent part of your marketing metrics</em></p>
+<ul>
+<li class="task-item"><label><input type="checkbox" disabled /> <span><strong>Screenshot or export your baseline scores</strong> from Day 1. This is your Week 0 benchmark.</span></label></li>
+<li class="task-item"><label><input type="checkbox" disabled /> <span><strong>Add AI Recommendations % and AI Visibility % to your monthly marketing report.</strong> Track it alongside organic traffic and branded search volume.</span></label></li>
+<li class="task-item"><label><input type="checkbox" disabled /> <span><strong>Schedule a monthly re-run of all conversations.</strong> Connect content actions to score changes over time.</span></label></li>
+<li class="task-item"><label><input type="checkbox" disabled /> <span><strong>Add new topics and scenarios</strong> based on what you learned this week.</span></label></li>
+</ul>
+<p><strong>End of Week 1 — what you now have:</strong></p>
+<ul>
+<li>Baseline AI Recommendations % and AI Visibility % across your key topics</li>
+<li>Citation source list — the domains to target for PR and link-building</li>
+<li>Perception audit — what AI says about you today (and what you want it to say)</li>
+<li>Prioritized action list from Actionable Insights</li>
+<li>First content brief assigned</li>
+<li>Monthly reporting rhythm established</li>
+</ul>
+<hr />
+<h2>Ongoing Monthly Rhythm</h2>
+<table>
+<thead><tr><th style="text-align:left">Cadence</th><th style="text-align:left">Activity</th><th style="text-align:left">Time</th></tr></thead>
+<tbody>
+<tr><td style="text-align:left"><strong>Weekly</strong></td><td style="text-align:left">Check Actionable Insights for new recommendations. Brief and assign 1–2 content pieces based on current gaps.</td><td style="text-align:left">30 min</td></tr>
+<tr><td style="text-align:left"><strong>Monthly</strong></td><td style="text-align:left">Run a full conversation batch. Review score changes. Update your content calendar based on what moved (or didn&#39;t). Report AI Recommendations % + AI Visibility % + Share of Voice to leadership.</td><td style="text-align:left">2 hours</td></tr>
+<tr><td style="text-align:left"><strong>Quarterly</strong></td><td style="text-align:left">Expand topic set. Add new scenarios reflecting seasonal or strategic priorities. Run Comparer Agent analysis on top 2 competitors to check narrative shifts.</td><td style="text-align:left">Half day</td></tr>
+</tbody>
+</table>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/index.html
+++ b/new-landing/public/docs/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Documentation | Genezio Docs</title>
+  <meta http-equiv="refresh" content="0; url=introduction/what-is-genezio.html" />
+  <link rel="canonical" href="introduction/what-is-genezio.html" />
+</head>
+<body>
+  <p>Redirecting to <a href="introduction/what-is-genezio.html">introduction/what-is-genezio.html</a>...</p>
+  <script>window.location.replace("introduction/what-is-genezio.html");</script>
+</body>
+</html>

--- a/new-landing/public/docs/insights/actionable-insights.html
+++ b/new-landing/public/docs/insights/actionable-insights.html
@@ -1,0 +1,230 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Actionable Insights | Genezio Docs</title>
+  <meta name="description" content="Actionable Insights in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="share-of-voice.html">Share of Voice</a></li><li><a class="" href="swot-analysis.html">SWOT Analysis</a></li><li><a class="active" href="actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Actionable Insights</h1>
+<p>The <strong>Actionable Insights</strong> section in Genezio surfaces strategic recommendations derived from the data generated by conversations, citations, perceptions, competitors, and visibility metrics.</p>
+<p>Actionable insights help teams understand <strong>what actions can improve their brand&#39;s AI Recommendations and Visibility</strong>.</p>
+<p>Instead of requiring users to manually analyze conversations and sources, Genezio continuously analyzes all collected data and generates actionable recommendations.</p>
+<hr />
+<h2>How Actionable Insights Are Generated</h2>
+<p>Insights are generated by analyzing all data collected for a brand, including:</p>
+<ul>
+<li>conversations</li>
+<li>follow-up searches (called query fanouts)</li>
+<li>citations (sources)</li>
+<li>perceptions</li>
+<li>competitors</li>
+<li>visibility metrics</li>
+<li>perception accuracy signals</li>
+<li>topic and scenario relevance</li>
+</ul>
+<p>This analysis runs <strong>automatically every day</strong>.</p>
+<p>As new conversations are executed and new data is collected, Genezio updates the insights to reflect the most recent state of the AI ecosystem.</p>
+<hr />
+<h2>Types of Actionable Insights</h2>
+<p>Insights are grouped into several categories that focus on different improvement opportunities.</p>
+<h3>Growth Opportunities</h3>
+<p>These insights identify <strong>areas where your brand could gain visibility</strong>.</p>
+<p>Examples include:</p>
+<ul>
+<li>topics where competitors dominate</li>
+<li>scenarios where brands are frequently recommended but yours is not</li>
+<li>emerging query patterns discovered through fanouts</li>
+</ul>
+<p>These insights help identify <strong>new opportunities for expansion</strong>.</p>
+<hr />
+<h3>Critical Visibility Gaps</h3>
+<p>These insights highlight <strong>areas where competitors significantly outperform your brand</strong>.</p>
+<p>Examples include:</p>
+<ul>
+<li>scenarios where competitors consistently appear but your brand does not</li>
+<li>decision moments where your brand is absent</li>
+<li>topics where competitors dominate AI recommendations</li>
+</ul>
+<p>These insights are often labeled <strong>high priority</strong> because they directly affect visibility.</p>
+<hr />
+<h3>Citation &amp; Authority Leverage</h3>
+<p>These insights focus on <strong>sources influencing AI answers</strong>.</p>
+<p>Examples include:</p>
+<ul>
+<li>influential websites citing competitors but not your brand</li>
+<li>authoritative sources shaping AI responses</li>
+<li>opportunities to improve citation coverage</li>
+</ul>
+<p>Improving presence in these sources can increase the likelihood that AI systems reference your brand.</p>
+<hr />
+<h3>Positioning &amp; Structural Optimization</h3>
+<p>These insights analyze <strong>how AI systems describe your brand</strong>.</p>
+<p>Examples include:</p>
+<ul>
+<li>narratives appearing in AI answers</li>
+<li>strengths or weaknesses repeatedly mentioned</li>
+<li>messaging gaps compared to competitors</li>
+</ul>
+<p>These insights help teams improve how their brand is <strong>positioned in the information ecosystem</strong>.</p>
+<hr />
+<h2>Automatic Insight Generation</h2>
+<p>Insights are generated <strong>automatically every day</strong>.</p>
+<p>The system analyzes the full dataset of conversations and extracts patterns that may indicate:</p>
+<ul>
+<li>competitive gaps</li>
+<li>citation weaknesses</li>
+<li>narrative issues</li>
+<li>growth opportunities</li>
+</ul>
+<p>New insights may appear as new conversations are executed and as AI responses evolve.</p>
+<hr />
+<h2>Manually Generating Actionable Insights</h2>
+<p>Users can also <strong>generate insights on demand</strong>.</p>
+<p>From the Insights page, you can click one of the insight category cards such as:</p>
+<ul>
+<li>Growth Opportunities</li>
+<li>Critical Visibility Gaps</li>
+<li>Citation &amp; Authority Leverage</li>
+<li>Positioning &amp; Structural Optimization</li>
+</ul>
+<p>When generating insights manually, you can optionally provide additional context such as:</p>
+<ul>
+<li>a specific <strong>topic</strong></li>
+<li>a specific <strong>scenario</strong></li>
+<li>additional instructions or strategic focus</li>
+</ul>
+<p>For example, you may request insights that focus on:</p>
+<ul>
+<li>improving visibility in a specific product category</li>
+<li>prioritizing high-impact actions</li>
+<li>identifying quick wins</li>
+</ul>
+<p>This allows teams to tailor insights to their specific strategic needs.</p>
+<hr />
+<h2>Understanding Actionable Insight Entries</h2>
+<p>Each insight includes:</p>
+<ul>
+<li>a <strong>summary of the issue or opportunity</strong></li>
+<li>the <strong>reason it was detected</strong></li>
+<li>relevant <strong>topics or scenarios</strong></li>
+<li>the <strong>priority level</strong> (for example High or Medium)</li>
+</ul>
+<p>Insights are designed to be <strong>actionable</strong>, meaning they describe specific improvements that can influence AI Recommendations and Visibility.</p>
+<hr />
+<h2>How Insights Are Presented</h2>
+<p>Insights are designed to be read quickly and shared with stakeholders without rewriting them. Each insight is structured for scanning, not paragraph-by-paragraph analysis.</p>
+<h3>Diagrams Where They Help</h3>
+<p>When an insight involves a process, a comparison, or a chain of cause and effect, Genezio renders it as a <strong>diagram</strong> inside the insight itself. Instead of a wall of text describing how three pieces connect, you see the connection.</p>
+<p>This makes it faster to grasp what&#39;s happening, and far easier to drop into a stakeholder deck or executive brief without redrawing anything.</p>
+<h3>Recommended Actions, Formatted for Scanning</h3>
+<p>Every insight ends with <strong>Recommended Actions</strong> — the specific things to do next. These are formatted with:</p>
+<ul>
+<li><strong>Icons</strong> that signal the kind of action (content, citation outreach, configuration change, and so on)</li>
+<li><strong>Answer-engine badges</strong> that show which engines the underlying signal was observed on</li>
+</ul>
+<p>The result: you can glance at an insight and immediately see <em>what to do</em> and <em>where the evidence came from</em>, without parsing prose. An insight backed by behavior seen on ChatGPT and Perplexity is now visibly tagged that way, so you know which engines the recommendation is grounded in.</p>
+<h3>Answer-Engine Icons Throughout</h3>
+<p>Answer-engine icons also appear in <strong>insight tooltips</strong> and <strong>across the charts</strong> that surround insights. When you hover on a number or a trend, you can see at a glance which engines contributed — no need to cross-reference a legend.</p>
+<h3>Why This Matters</h3>
+<p>Insights is the part of the platform that tells you what to do. Structured presentation — diagrams, action icons, engine badges — turns each insight from a paragraph of analyst notes into something closer to a <strong>takeaway slide</strong>: ready to scan, ready to share, ready to act on.</p>
+<hr />
+<h2>Managing Insights</h2>
+<p>Users can manage insights directly from the Insights interface.</p>
+<p>Each insight can be:</p>
+<h3>Marked as Done</h3>
+<p>If the recommended action has been implemented, the insight can be marked as <strong>Done</strong>.</p>
+<p>This helps teams track which opportunities have already been addressed.</p>
+<hr />
+<h3>Dismissed</h3>
+<p>If an insight is not relevant or cannot be acted upon, it can be <strong>dismissed</strong>.</p>
+<p>For example, this may happen when:</p>
+<ul>
+<li>the recommendation cannot be implemented</li>
+<li>the insight does not apply to the brand&#39;s strategy</li>
+<li>the issue is outside the organization&#39;s control</li>
+</ul>
+<p>Dismissing an insight removes it from the active list so teams can focus on more relevant opportunities.</p>
+<p>Managing insights this way allows teams to treat them as a <strong>workflow of improvements</strong>, rather than just a static report.</p>
+<hr />
+<h2>Why Actionable Insights Matter</h2>
+<p>The AI visibility landscape is complex. Conversations, citations, competitors, and perceptions all interact to shape AI-generated answers.</p>
+<p>Insights help translate this complex data into <strong>clear recommendations</strong>.</p>
+<p>Instead of analyzing hundreds of conversations manually, teams can focus on the actions most likely to improve their visibility in AI systems.</p>
+<hr />
+<h2>Next Steps</h2>
+<p>To understand the data that powers insights, see:</p>
+<ul>
+<li><a href="../core-concepts/conversations.html">Core Concepts -&gt; Conversations</a></li>
+<li><a href="../core-concepts/citations.html">Core Concepts -&gt; Citations</a></li>
+<li><a href="../core-concepts/perceptions.html">Core Concepts -&gt; Perceptions</a></li>
+<li><a href="../core-concepts/competitors.html">Core Concepts -&gt; Competitors</a></li>
+</ul>
+<p>These pages explain how Genezio collects and structures the data used to generate insights.</p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/insights/ai-perception-summary.html
+++ b/new-landing/public/docs/insights/ai-perception-summary.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>AI Perception Summary | Genezio Docs</title>
+  <meta name="description" content="AI Perception Summary in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="active" href="ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="share-of-voice.html">Share of Voice</a></li><li><a class="" href="swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>AI Perception Summary</h1>
+<p>The <strong>AI Perception Summary</strong> is an auto-generated narrative that explains, in plain language, how your brand is currently perceived across the major LLMs (the answer engines people now ask instead of searching). Instead of reading through dozens of individual data points, you get a single readable paragraph that captures the overall story.</p>
+<p>It appears as the <strong>Overall AI Perception</strong> card on your brand report — a large, dedicated component near the top of the page.</p>
+<hr />
+<h2>Why It Matters</h2>
+<p>Most of the data in your brand report is detailed and granular. That&#39;s powerful for analysis, but it&#39;s not something you can paste straight into an executive update.</p>
+<p>The AI Perception Summary solves that. It synthesizes the signals Genezio tracks into one coherent narrative, so you can:</p>
+<ul>
+<li>Drop a ready-made paragraph into a stakeholder update or board deck.</li>
+<li>Give leadership a quick, accurate sense of how AI engines talk about the brand.</li>
+<li>Frame a starting point for deeper investigation, without having to assemble the story yourself.</li>
+</ul>
+<p>It pulls together three kinds of signal:</p>
+<ul>
+<li><strong>Perceptions</strong> — the individual claims AI engines make about your brand (see <a href="../core-concepts/perceptions.html">Perceptions</a>).</li>
+<li><strong>Sentiment</strong> — whether those claims lean positive, neutral, or negative.</li>
+<li><strong>Competitor framing</strong> — how your brand is positioned relative to others in the same answers.</li>
+</ul>
+<p>A quick note for marketers: the summary is generated in the brand&#39;s own language, so multi-language reports read naturally for the audience that owns them.</p>
+<hr />
+<h2>Where to Find It</h2>
+<ol>
+<li>Open your <strong>brand report</strong>.</li>
+<li>Look for the <strong>Overall AI Perception</strong> card near the top of the page.</li>
+<li>Read the summary directly, or copy it into your own document.</li>
+</ol>
+<p>The summary is produced by Genezio&#39;s analysis engine and cached, so the card loads quickly each time you return to the report.</p>
+<hr />
+<h2>When It Appears</h2>
+<p>The AI Perception Summary is only shown when there is enough data to make it meaningful.</p>
+<p>In particular, it is hidden when only a single answer-engine model is configured for the brand. Cross-model perception is only interesting when there are multiple models to compare — one model on its own can&#39;t show you how perception varies across the AI landscape.</p>
+<p>If you don&#39;t see the card, check that more than one model is configured and that the brand has been analyzed.</p>
+<hr />
+<h2>How It Relates to Perceptions and Sentiment</h2>
+<p>Think of the summary as the headline, and Perceptions and Sentiment as the supporting detail:</p>
+<ul>
+<li>The <strong>AI Perception Summary</strong> gives you the big-picture narrative.</li>
+<li><strong>Perceptions</strong> let you drill into the specific claims behind that narrative.</li>
+<li><strong>Sentiment</strong> shows you the tone and direction of those claims over time.</li>
+</ul>
+<p>The summary also feeds the <strong>Geo Assistant&#39;s</strong> context. That means you can ask Geo follow-up questions about your overall AI perception and get answers grounded in the same data the card is built from. See <a href="../geo-assistant/geo-assistant.html">Geo Assistant</a>.</p>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="../core-concepts/perceptions.html">Perceptions</a></li>
+<li><a href="sentiment-analysis.html">Sentiment Analysis</a></li>
+<li><a href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li>
+<li><a href="your-kpis-explained.html">Your KPIs Explained</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/insights/share-of-voice.html
+++ b/new-landing/public/docs/insights/share-of-voice.html
@@ -1,0 +1,135 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Share of Voice | Genezio Docs</title>
+  <meta name="description" content="Share of Voice in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="ai-perception-summary.html">AI Perception Summary</a></li><li><a class="active" href="share-of-voice.html">Share of Voice</a></li><li><a class="" href="swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Share of Voice</h1>
+<p><strong>Share of Voice (SOV)</strong> is a brand-level metric that answers the question every executive eventually asks: <strong>&quot;how much of the conversation is mine versus my competitors&#39;?&quot;</strong></p>
+<p>It sits alongside <a href="your-kpis-explained.html">AI Recommendations</a> and <a href="ai-visibility-score.html">AI Visibility</a> as one of Genezio&#39;s headline numbers — and it&#39;s typically the one that ends up in board decks and quarterly reviews.</p>
+<hr />
+<h2>What Share of Voice Measures</h2>
+<p>SOV tracks the share of <strong>all brand mentions</strong> in your category — yours versus every competitor&#39;s.</p>
+<p>Where AI Recommendations asks <em>how often are you recommended</em> and AI Visibility asks <em>how often you appear</em>, Share of Voice asks <em>what slice of the total conversation is yours</em>. It&#39;s broader than Recommendations: it counts <strong>every mention</strong> of you and your competitors across the answer engines Genezio monitors, not just the ones that ended in a recommendation.</p>
+<p>That&#39;s what makes it useful as a market-share proxy. Hundreds of LLM signals collapse into a single percentage that&#39;s easy to compare period over period and easy to take to a stakeholder review.</p>
+<hr />
+<h2>Why It Matters</h2>
+<p>Until SOV, the platform answered two of the three questions a marketer needs to bring to leadership:</p>
+<ol>
+<li><strong>&quot;How often do I appear?&quot;</strong> — AI Visibility</li>
+<li><strong>&quot;What do they say about me?&quot;</strong> — sentiment, citations, narratives</li>
+</ol>
+<p>Share of Voice adds the third:</p>
+<ol>
+<li><strong>&quot;How much of the conversation is mine vs. theirs?&quot;</strong></li>
+</ol>
+<p>This is the metric leadership intuitively understands. It converts the platform&#39;s underlying signal into a market-share number — the same shape of metric marketing teams have always reported on for traditional channels.</p>
+<hr />
+<h2>When Share of Voice Is Shown</h2>
+<p>Share of Voice only appears when there&#39;s enough cross-model and competitive data to make it meaningful. When that signal isn&#39;t there, the metric is <strong>hidden rather than shown as a misleading number</strong>.</p>
+<p>You won&#39;t see SOV, for example, when a brand runs against only a single answer-engine model, or for <strong>industry-only brands</strong> where there&#39;s no competitive set and a &quot;share&quot; doesn&#39;t apply.</p>
+<p>In short: you&#39;ll only see Share of Voice when there&#39;s enough competitive, cross-model data behind it to make the percentage trustworthy.</p>
+<hr />
+<h2>How to Read Share of Voice</h2>
+<p>SOV is <strong>brand-wide</strong> and measured over a <strong>time range</strong>. The headline number is your share of all mentions across your tracked topics, for the period you&#39;ve selected.</p>
+<p>A few rules of thumb:</p>
+<ul>
+<li><strong>Trend matters more than the absolute number.</strong> A 22% SOV that&#39;s been climbing for three months is a healthier story than a flat 35%.</li>
+<li><strong>Compare against your top two or three competitors, not against an industry benchmark.</strong> SOV is meaningful within your category; cross-category comparisons aren&#39;t.</li>
+<li><strong>Pair it with AI Recommendations.</strong> A high SOV with a low Recommendation rate tells a different story than a low SOV with a high Recommendation rate — the first means you&#39;re talked about but not picked, the second means you&#39;re a hidden favorite. Read them together.</li>
+</ul>
+<hr />
+<h2>The Share of Voice View</h2>
+<p>A dedicated <strong>Share of Voice</strong> section in the dashboard breaks the metric down three ways:</p>
+<h3>Overview</h3>
+<p>A pie chart of how mention share splits between your brand and each tracked competitor for the selected time range. This is the headline view — the single picture you&#39;d put in a board deck.</p>
+<h3>Top Topics</h3>
+<p>A breakdown of <strong>which topics drive the most mentions overall</strong> — across you and competitors combined. Tells you where the conversation is concentrated, regardless of who&#39;s winning. Useful for deciding where to invest: a topic with low total mentions probably isn&#39;t worth a content push, even if you&#39;re losing it.</p>
+<h3>Competitors by Topic</h3>
+<p>A topic-by-topic view of <strong>who dominates each topic</strong>. For every topic you track, you see how share splits between you and your competitors.</p>
+<p>This is where you find the actionable detail: the topics where you&#39;re winning the conversation, and the topics where a specific competitor is taking it. It&#39;s the input to a content plan — fix the topics where you&#39;re losing share, defend the ones where you&#39;re winning.</p>
+<hr />
+<h2>How to Use Share of Voice in Practice</h2>
+<ul>
+<li><strong>In monthly reporting</strong> — lead with the SOV number and its trend. Pair it with AI Recommendations to show both <em>presence</em> and <em>conversion</em>.</li>
+<li><strong>In quarterly reviews</strong> — show SOV against your top two or three competitors, broken down by topic. This is where the Competitors-by-Topic view earns its keep.</li>
+<li><strong>In planning content</strong> — start from Top Topics (where is the conversation?) and Competitors by Topic (where are we losing it?). Prioritize content that improves SOV in topics that have high total volume.</li>
+<li><strong>In tracking outcomes</strong> — after publishing or fixing content, watch SOV in the affected topic. Movement there is one of the cleanest signals that the work mattered.</li>
+</ul>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="your-kpis-explained.html">Your KPIs Explained</a></li>
+<li><a href="ai-visibility-score.html">AI Visibility Score</a></li>
+<li><a href="competitor-insights.html">Competitor Insights</a></li>
+<li><a href="../core-concepts/competitors.html">Core Concepts -&gt; Competitors</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/insights/swot-analysis.html
+++ b/new-landing/public/docs/insights/swot-analysis.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>SWOT Analysis | Genezio Docs</title>
+  <meta name="description" content="SWOT Analysis in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="share-of-voice.html">Share of Voice</a></li><li><a class="active" href="swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>SWOT Analysis</h1>
+<p>Genezio automatically extracts a <strong>SWOT analysis</strong> (Strengths, Weaknesses, Opportunities, Threats) from Comparer conversations — showing how AI systems position your brand against the specific competitors you compete with.</p>
+<p>SWOT is generated from the language answer engines use when comparing brands head-to-head: which strengths they highlight, which weaknesses they raise, where competitors look more favorable, and where your brand has room to gain ground.</p>
+<hr />
+<h2>Selecting Which Competitors to Compare Against</h2>
+<p>For every topic, you can pick the exact set of competitors that the Comparer Agent should evaluate your brand against.</p>
+<p>This selection is made <strong>at the topic level</strong> and is used when Genezio auto-generates Comparer scenarios for that topic. Instead of comparing your brand against any brand that happens to surface in AI answers, Comparer scenarios target the specific competitors you care about.</p>
+<p>Choosing the right competitors per topic gives you a focused, decision-useful SWOT — one that reflects the actual market you&#39;re competing in for that subject area.</p>
+<hr />
+<h2>SWOT in the Conversation Drawer</h2>
+<p>When you open a Comparer-type conversation in the <strong>conversation drawer</strong>, Genezio displays an inline SWOT analysis directly in the view.</p>
+<p>The SWOT shows:</p>
+<ul>
+<li><strong>Strengths</strong> — what answer engines say your brand does well versus the competitors in the conversation</li>
+<li><strong>Weaknesses</strong> — limitations or objections answer engines raise about your brand</li>
+<li><strong>Opportunities</strong> — areas where competitors are vulnerable or where AI positioning is unstable</li>
+<li><strong>Threats</strong> — areas where competitors are framed more favorably than your brand</li>
+</ul>
+<p>The same SWOT is also aggregated and shown at the <strong>scenario</strong> and <strong>topic</strong> level, so you can move from a single conversation up to the broader competitive picture without losing the underlying evidence.</p>
+<hr />
+<h2>SWOT Comparison View</h2>
+<p>For an overall view across your full competitive landscape, Genezio provides a dedicated <strong>SWOT Comparison</strong> view, available from the menu under <strong>Competitors -&gt; SWOT</strong>.</p>
+<p>This view displays a SWOT analysis for:</p>
+<ul>
+<li>your brand</li>
+<li>each of your tracked competitors</li>
+</ul>
+<p>Seeing all SWOTs side by side helps you spot patterns — recurring strengths competitors share, weaknesses unique to your brand, and opportunities where no competitor is currently positioned well.</p>
+<p><strong>Competitor logos</strong> are shown throughout the SWOT views, making the side-by-side comparison faster to scan — you can recognize each brand at a glance instead of reading down a list of names.</p>
+<hr />
+<h2>Sources Behind Each SWOT Point</h2>
+<p>Every SWOT point can be traced back to the evidence that produced it. For each strength, weakness, opportunity, or threat, Genezio can surface the <strong>citation paragraphs (sources)</strong> that back it — the actual passages from the webpages answer engines drew on — with the <strong>matching text highlighted</strong>.</p>
+<p>This means you can move from a high-level claim (&quot;competitors are framed as more affordable&quot;) straight to the exact webpage passage that produced it, without guessing where the framing came from.</p>
+<p>It&#39;s the same source-tracing already available for <a href="../core-concepts/perceptions.html">perceptions</a>, now applied to your competitive SWOT — so every strength, weakness, opportunity, and threat is auditable down to the source paragraph.</p>
+<hr />
+<h2>How SWOT Is Generated</h2>
+<p>SWOT insights are derived from <strong>Comparer Agent</strong> conversations only. Because Comparer conversations name brands explicitly in the prompt, answer engines respond with direct head-to-head framing, which is the signal Genezio needs to extract Strengths, Weaknesses, Opportunities, and Threats.</p>
+<p>Prompter, Recommender, and Introspector conversations do not contribute to SWOT — those agents are designed for unbranded discovery and brand-perception measurement, not direct comparison.</p>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="../genezio-agents/comparer-agent.html">Genezio Agents -&gt; Comparer Agent</a></li>
+<li><a href="../core-concepts/competitors.html">Core Concepts -&gt; Competitors</a></li>
+<li><a href="../core-concepts/topics.html">Core Concepts -&gt; Topics</a></li>
+<li><a href="competitor-insights.html">Insights -&gt; Competitor Insights</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/insights/your-kpis-explained.html
+++ b/new-landing/public/docs/insights/your-kpis-explained.html
@@ -1,0 +1,154 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Your KPIs Explained | Genezio Docs</title>
+  <meta name="description" content="Your KPIs Explained in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="active" href="your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="share-of-voice.html">Share of Voice</a></li><li><a class="" href="swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Your KPIs Explained</h1>
+<p><em>Genezio measures three core numbers. Here&#39;s what they mean, why they&#39;re different, and how to read them together on your monthly dashboard.</em></p>
+<hr />
+<h2>The Three Numbers That Matter</h2>
+<h3>KPI #1 — AI Recommendations %</h3>
+<p><strong>Formula:</strong> Conversations where brand was recommended ÷ Conversations where brand was visible × 100</p>
+<p>When answer engines mention your brand, how often do they go further and actually recommend it? This is your <strong>conversion score</strong> — the strongest signal of purchase intent. The denominator is only conversations where your brand appeared, so this measures your conversion rate from visibility to recommendation.</p>
+<h3>KPI #2 — AI Visibility %</h3>
+<p><strong>Formula:</strong> Conversations where brand appears ÷ Total eligible conversations × 100</p>
+<p>How often does your brand show up in AI answers? This is your <strong>presence score</strong> — the broadest view of how frequently AI assistants mention, list, or reference your brand when answering questions in your category.</p>
+<h3>KPI #3 — Share of Voice %</h3>
+<p><strong>Formula:</strong> Mentions of your brand ÷ Mentions of all brands (you and competitors) × 100</p>
+<p>What slice of the total category conversation is yours? This is your <strong>market-share score</strong> — the metric that maps most cleanly to how leadership thinks about brand presence. It counts every mention of you and your competitors across the answer engines Genezio monitors, so it captures the full conversation, not just the recommendation moments.</p>
+<p>See <a href="share-of-voice.html">Share of Voice</a> for the dedicated dashboard view that breaks SOV down by topic and competitor.</p>
+<blockquote><p><strong>Simple analogy:</strong> AI Recommendations is like word-of-mouth — people actively suggest you. AI Visibility is like brand awareness — people have heard of you. Share of Voice is market share — how much of the conversation is yours. You want all three, but each tells you something different.</p></blockquote>
+<hr />
+<h2>How These KPIs Are Measured</h2>
+<p>Both KPIs are <strong>brand-level metrics</strong>, calculated across all conversations Genezio runs for your brand. They are not tied to a single agent type — they are the output of Genezio&#39;s conversation analysis engine.</p>
+<p>Here&#39;s how it works:</p>
+<ol>
+<li>Genezio runs persona-driven, multi-step conversations with answer engines (ChatGPT, Claude, Gemini, Perplexity).</li>
+<li>Each response is analyzed to extract which brands were mentioned, which were recommended, and what was said about each.</li>
+<li>These signals are aggregated at the brand level to calculate your AI Recommendations % and AI Visibility %.</li>
+</ol>
+<p>The conversations that feed these KPIs come from two agent types:</p>
+<ul>
+<li><strong>Prompter conversations</strong> — open-ended discovery questions where the AI chooses which brands to mention. <em>&quot;What are the best tools for X?&quot;</em></li>
+<li><strong>Recommender conversations</strong> — scenario-driven, multi-step conversations where the AI recommends specific brands for the persona&#39;s situation. <em>&quot;Recommend something for Y given these constraints.&quot;</em></li>
+</ul>
+<p>Both agent types let the AI decide freely which brands to surface. That&#39;s what makes the resulting metrics meaningful — they reflect organic brand presence and genuine recommendation decisions, not prompted mentions.</p>
+<hr />
+<h2>What About Comparer and Introspector?</h2>
+<p>Genezio runs two additional agent types, but they serve a different purpose:</p>
+<ul>
+<li><strong>Introspector conversations</strong> — <em>&quot;Tell me about [your brand].&quot;</em> These explore how AI describes your brand. Because your brand is named in the question, these conversations are used for <strong>narrative and sentiment analysis</strong>, not for calculating KPIs.</li>
+</ul>
+<ul>
+<li><strong>Comparer conversations</strong> — <em>&quot;[Brand A] vs [Brand B].&quot;</em> These are a <strong>competitive analysis tool</strong>. The Comparer does not compute visibility or recommendations — it consumes the brand-level metrics that Genezio has already calculated and uses them alongside head-to-head AI conversations to show how your brand stacks up against specific competitors. Think of the Comparer as a lens for reading your KPIs, not the engine that generates them.</li>
+</ul>
+<blockquote><p><strong>Key distinction:</strong> Your AI Recommendations % and AI Visibility % come from Prompter and Recommender conversations. The Comparer helps you understand those numbers in a competitive context — it doesn&#39;t change or contribute to them.</p></blockquote>
+<hr />
+<h2>How to Read Your Scores</h2>
+<p>There&#39;s no universal &quot;good&quot; score — it depends on your category, competitive intensity, and how long you&#39;ve been tracking. Here&#39;s a general benchmark framework:</p>
+<table>
+<thead><tr><th style="text-align:left">Score Range</th><th style="text-align:left">What It Means</th><th style="text-align:left">What to Do</th></tr></thead>
+<tbody>
+<tr><td style="text-align:left"><strong>0–15%</strong></td><td style="text-align:left">Your brand is largely invisible in AI answers for this topic. Competitors dominate.</td><td style="text-align:left">Urgent: create foundational content, get cited by authoritative sources, fix schema markup.</td></tr>
+<tr><td style="text-align:left"><strong>15–35%</strong></td><td style="text-align:left">You appear sometimes, but inconsistently. answer engines know you exist but don&#39;t prioritize you.</td><td style="text-align:left">Focus: identify which sources cite competitors but not you, and close those gaps.</td></tr>
+<tr><td style="text-align:left"><strong>35–60%</strong></td><td style="text-align:left">Solid presence. You&#39;re a recognized brand in AI answers for this topic.</td><td style="text-align:left">Grow: expand to adjacent topics, improve sentiment, increase recommendation rate.</td></tr>
+<tr><td style="text-align:left"><strong>60%+</strong></td><td style="text-align:left">Category leader. answer engines consistently include you in this topic area.</td><td style="text-align:left">Defend: monitor competitor improvements, expand to new topics, protect share of voice.</td></tr>
+</tbody>
+</table>
+<hr />
+<h2>A Practical Example</h2>
+<blockquote><p><strong>Scenario: CRM Software Brand</strong>  You track the topic <em>&quot;CRM for startups&quot;</em> across 200 AI conversations (Prompter + Recommender).  <strong>AI Visibility:</strong> Your brand appears in 160 of 200 conversations → 160 / 200 = <strong>80%</strong>  <strong>AI Recommendations:</strong> Of those 160 visible conversations, your brand was actively recommended in 96 → 96 / 160 = <strong>60%</strong>  Note: the Recommendation denominator is <strong>visible conversations (160)</strong>, not total conversations (200). This tells you that when answer engines mention your brand, they recommend it 60% of the time.  Your top competitor appears in 180 of 200 conversations (90% visibility) and is recommended in 144 of those 180 (80% recommendations). <strong>That gap is your roadmap.</strong>  You then use the <strong>Comparer</strong> to run head-to-head conversations — <em>&quot;Your brand vs. Competitor X&quot;</em> — to understand exactly how answer engines frame the comparison and what narratives are driving the competitor&#39;s advantage.</p></blockquote>
+<hr />
+<h2>Why the Two KPIs Are Measured Separately</h2>
+<p>A brand can have high visibility but low recommendations — or the reverse. Understanding which scenario you&#39;re in tells you exactly what to fix:</p>
+<table>
+<thead><tr><th style="text-align:left">Pattern</th><th style="text-align:left">What It Means</th><th style="text-align:left">Action</th></tr></thead>
+<tbody>
+<tr><td style="text-align:left"><strong>High Visibility, Low Recommendations</strong></td><td style="text-align:left">AI mentions you, but doesn&#39;t suggest you when asked to pick. You may be seen as secondary or niche.</td><td style="text-align:left">Improve positioning content. Get cited in &quot;best of&quot; lists. Fix inaccurate claims AI makes about your brand.</td></tr>
+<tr><td style="text-align:left"><strong>Low Visibility, High Recommendations</strong></td><td style="text-align:left">When AI mentions you, it recommends you — but that&#39;s rare. You&#39;re a hidden gem.</td><td style="text-align:left">Increase content volume. Get mentioned in more sources. Expand topic coverage.</td></tr>
+<tr><td style="text-align:left"><strong>Both Low</strong></td><td style="text-align:left">answer engines don&#39;t know enough about your brand to confidently mention or recommend you.</td><td style="text-align:left">Start from scratch: content authority, citations, schema, PR. Use Genezio&#39;s Actionable Insights to prioritize.</td></tr>
+<tr><td style="text-align:left"><strong>Both High</strong></td><td style="text-align:left">You&#39;re a category leader in AI answers. Now protect it and expand.</td><td style="text-align:left">Monitor competitor movements. Track new topics. Measure claim accuracy, not just mention frequency.</td></tr>
+</tbody>
+</table>
+<hr />
+<h2>How to Report These KPIs to Leadership</h2>
+<p>For your monthly or quarterly marketing review, we recommend presenting:</p>
+<ul>
+<li><strong>AI Recommendations % by topic</strong> — the single most business-relevant number</li>
+<li><strong>AI Visibility % by topic</strong> — shows breadth of brand presence across answer engines</li>
+<li><strong>Share of Voice vs. top 2 competitors</strong> — the competitive story (powered by the Comparer)</li>
+<li><strong>Month-over-month trend</strong> — shows whether your content investments are working</li>
+</ul>
+<blockquote><p><strong>Common mistake:</strong> Don&#39;t benchmark your score against absolute numbers from other industries. A 40% AI Visibility in a crowded SaaS category may be excellent; 40% in a niche B2B space may indicate room to grow. Always compare against your direct competitors&#39; scores within the same topic set.</p></blockquote>
+<hr />
+<p><em>Next: <a href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></em></p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/integrations/cdn-log-integration.html
+++ b/new-landing/public/docs/integrations/cdn-log-integration.html
@@ -1,0 +1,134 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>CDN Log Integration | Genezio Docs</title>
+  <meta name="description" content="CDN Log Integration in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../introduction/what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="../introduction/what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="../introduction/why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="../introduction/how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="../introduction/query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="../introduction/how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="../introduction/how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="../introduction/what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="../introduction/how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="../introduction/how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="active" href="cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>CDN Log Integration</h1>
+<p><strong>CDN log analysis</strong> lets you upload your own server-side access logs to Genezio and see exactly which pages AI crawlers are fetching from your site — then compare that against the pages AI engines actually cite in their answers.</p>
+<p>This turns your raw CDN and web server logs into a clear picture of how AI answer engines discover, crawl, and use your content. It complements Genezio&#39;s citation data with first-party evidence straight from your own infrastructure.</p>
+<hr />
+<h2>Why It Matters</h2>
+<p>Citation tracking tells you which of your pages show up in AI answers. CDN log analysis tells you the other half of the story: what AI crawlers are actually fetching in the first place.</p>
+<p>Together, they help you answer questions like:</p>
+<ul>
+<li>Are AI engines crawling my most important content, or ignoring it?</li>
+<li>Which high-value pages do AI bots never visit?</li>
+<li>Which pages get crawled often but are never cited?</li>
+<li>Is my crawl budget going to the content I care about?</li>
+</ul>
+<p>Because it draws on your own server logs, this is direct, first-party evidence — not an estimate. It gives you a ground-truth view to pair with the citation insights elsewhere in Genezio.</p>
+<hr />
+<h2>What You Can Upload</h2>
+<p>You upload your <strong>CDN or web server access logs</strong> — the standard logs your CDN or origin server already records for every request:</p>
+<ul>
+<li>The URLs and paths visitors and bots requested</li>
+<li>The user agents identifying who made each request (including AI crawlers)</li>
+</ul>
+<p>These are the same logs your infrastructure team can typically export from your CDN or web server. No special instrumentation is required.</p>
+<hr />
+<h2>How It Works</h2>
+<h3>Clustering by keyword</h3>
+<p>Raw logs are long lists of individual URLs, which are hard to read on their own. Genezio <strong>clusters</strong> your log entries by keyword, grouping requested paths into themes so you can see traffic at the level of topics rather than single URLs.</p>
+<p>You can run <strong>multiple clusterings</strong> on the same logs — cluster them one way, save it, then cluster them another way for a different perspective. Saved clusterings stay available so you can revisit or compare them later.</p>
+<h3>Crawler breakdown</h3>
+<p>Genezio produces a <strong>crawler breakdown</strong> that identifies which bots and crawlers are hitting your site, with particular emphasis on <strong>AI crawlers</strong> — the crawlers AI answer engines use to fetch and index content for their responses.</p>
+<p>This shows you who is actually visiting, separating AI engine crawlers from search engines, scrapers, and ordinary traffic.</p>
+<h3>AI-crawler traffic vs. citations</h3>
+<p>The most valuable view connects the two halves of the story: Genezio analyzes <strong>AI-crawler traffic against your citations</strong>, checking whether the pages AI crawlers are fetching line up with the pages that actually get cited in AI answers.</p>
+<p>This is where gaps surface — important pages AI bots ignore, or pages they crawl heavily but never cite — so you know where to focus.</p>
+<hr />
+<h2>Reading the Results</h2>
+<p>When reviewing your CDN log analysis, look for:</p>
+<ul>
+<li><strong>Coverage gaps</strong> — high-value pages that AI crawlers rarely or never fetch.</li>
+<li><strong>Crawled-but-not-cited pages</strong> — content AI bots fetch but that never appears in answers, which may signal a content or relevance issue.</li>
+<li><strong>Crawler mix</strong> — how much of your bot traffic comes from AI engines versus other crawlers.</li>
+<li><strong>Theme-level patterns</strong> — using your keyword clusters to see which content areas get the most AI-crawler attention.</li>
+</ul>
+<hr />
+<h2>How to Get Started</h2>
+<ol>
+<li>Go to <strong>Settings -&gt; Integrations</strong> and open CDN Log Integration.</li>
+<li>Upload your CDN or web server access logs.</li>
+<li>Run a clustering to group the requested paths by keyword, and save it. Run additional clusterings if you want a different view of the same logs.</li>
+<li>Review the crawler breakdown to see which AI crawlers are visiting, then open the AI-crawler-traffic-vs-citations analysis to spot coverage and citation gaps.</li>
+</ol>
+<p>You can also explore all of this through the <a href="../geo-assistant/geo-assistant.html">Geo Assistant</a> — most CDN log operations are exposed as assistant tools, so you can simply ask about your CDN log clusters, crawler breakdown, and how crawl activity compares to your citations.</p>
+<hr />
+<h2>Related Pages</h2>
+<ul>
+<li><a href="../core-concepts/citations.html">Citations</a></li>
+<li><a href="../insights/most-cited-sources.html">Most Cited Sources</a></li>
+<li><a href="data-exports.html">Data Exports</a></li>
+<li><a href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/introduction/how-ai-citations-work.html
+++ b/new-landing/public/docs/introduction/how-ai-citations-work.html
@@ -1,0 +1,193 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>How AI Citations Work | Genezio Docs</title>
+  <meta name="description" content="How AI Citations Work in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="active" href="how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>How AI Citations Work</h1>
+<p>When AI systems such as ChatGPT, Claude, Gemini, or Perplexity generate answers, they often rely on information retrieved from external sources. Some systems make this process visible by including <strong>citations</strong>-links or references to the pages that influenced the generated response.</p>
+<p>AI citations help explain <strong>where information in an answer came from</strong> and allow users to explore the original sources.</p>
+<hr />
+<h2>What Is an AI Citation?</h2>
+<p>An <strong>AI citation</strong> is a reference to a source that contributed information to an AI-generated answer.</p>
+<p>Depending on the system, citations may appear as:</p>
+<ul>
+<li>links to websites</li>
+<li>numbered references</li>
+<li>inline source indicators</li>
+<li>expandable source lists</li>
+</ul>
+<p>For example, an AI answer might include a claim like:</p>
+<blockquote><p>The best CRM platforms for startups include HubSpot, Pipedrive, and Zoho CRM.</p></blockquote>
+<p>The answer may include citations pointing to:</p>
+<ul>
+<li>comparison articles</li>
+<li>software review sites</li>
+<li>vendor documentation</li>
+<li>editorial content</li>
+</ul>
+<p>These citations help users verify the information and learn more about the topic.</p>
+<hr />
+<h2>Why AI Systems Use Citations</h2>
+<p>Citations serve several purposes in AI-generated answers.</p>
+<h3>Transparency</h3>
+<p>They show users where the information came from, allowing them to verify the claims made in the answer.</p>
+<h3>Credibility</h3>
+<p>Answers supported by reputable sources are generally considered more trustworthy.</p>
+<h3>Exploration</h3>
+<p>Citations allow users to click through to original articles or resources for deeper research.</p>
+<hr />
+<h2>How Citations Are Selected</h2>
+<p>Citations usually originate from the <strong>documents retrieved during the retrieval stage</strong> of the AI search process.</p>
+<p>The process typically looks like this:</p>
+<ol>
+<li>The user asks a question.</li>
+<li>The system generates related queries (follow-up searches, called query fanouts).</li>
+<li>Relevant documents are retrieved.</li>
+<li>The model analyzes those documents.</li>
+<li>The model generates an answer using the information.</li>
+<li>Some of the retrieved sources are displayed as citations.</li>
+</ol>
+<p>Because citations come from retrieved documents, they reflect the sources the model considered most relevant or useful for constructing the answer.</p>
+<hr />
+<h2>What Citations Reveal</h2>
+<p>Citations provide important signals about how AI systems understand a topic.</p>
+<p>They reveal:</p>
+<ul>
+<li>which websites influence AI answers</li>
+<li>which sources are considered authoritative</li>
+<li>where information about a topic is concentrated</li>
+<li>which brands are associated with a topic</li>
+</ul>
+<p>For example, if multiple AI systems frequently cite the same review sites or editorial articles for a category, those sources likely have strong influence on how AI systems interpret that topic.</p>
+<hr />
+<h2>Citations vs Mentions</h2>
+<p>A brand appearing in an AI answer does not always mean the brand&#39;s own website was cited.</p>
+<p>Two scenarios are common:</p>
+<h3>Brand Mention Without Citation</h3>
+<p>The model mentions a brand based on information gathered from third-party sources.</p>
+<p>Example:</p>
+<blockquote><p>Popular project management tools include Notion, Asana, and Monday.com.</p></blockquote>
+<p>In this case, the answer may cite review articles rather than the official product websites.</p>
+<h3>Brand Website Citation</h3>
+<p>The answer includes a direct reference to the brand&#39;s website or documentation.</p>
+<p>Example:</p>
+<blockquote><p>According to the Notion documentation, teams can use databases to manage tasks and workflows.</p></blockquote>
+<p>Both types of visibility are important but represent different kinds of influence.</p>
+<hr />
+<h2>Why Citations Matter for AI Recommendations</h2>
+<p>Citations help explain <strong>why certain brands appear in AI answers</strong>.</p>
+<p>If a brand or its website is frequently cited, it signals that the AI system considers those sources useful or relevant when answering questions about a topic.</p>
+<p>Brands that rarely appear in cited sources may have lower visibility in AI answers.</p>
+<p>Understanding which sources are cited can therefore help organizations identify:</p>
+<ul>
+<li>influential websites in their category</li>
+<li>content that shapes AI responses</li>
+<li>opportunities to improve visibility</li>
+</ul>
+<hr />
+<h2>How Genezio Analyzes Citations</h2>
+<p>Genezio extracts citations from AI-generated answers and analyzes them across many conversations.</p>
+<p>This allows teams to see:</p>
+<ul>
+<li>which sources are most frequently cited</li>
+<li>which sources mention their brand</li>
+<li>which sources mention competitors</li>
+<li>which sources dominate a specific topic</li>
+</ul>
+<p>By aggregating this information, Genezio helps organizations understand the <strong>information landscape that AI systems rely on</strong>.</p>
+<hr />
+<h2>Example</h2>
+<p>Consider the question:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>What are the best tools for managing a startup sales pipeline?</strong></em></p></blockquote>
+<p>An AI system might generate an answer mentioning:</p>
+<ul>
+<li>HubSpot</li>
+<li>Pipedrive</li>
+<li>Salesforce</li>
+</ul>
+<p>The citations might include:</p>
+<ul>
+<li>software comparison websites</li>
+<li>SaaS review platforms</li>
+<li>blog articles comparing CRM tools</li>
+</ul>
+<p>Even if the official vendor websites are not cited directly, the third-party sources that mention those brands help shape the answer.</p>
+<hr />
+<h2>Next Steps</h2>
+<p>To continue exploring how Genezio analyzes AI answers, see:</p>
+<ul>
+<li><a href="../core-concepts/perceptions.html">Core Concepts -&gt; Perceptions</a></li>
+<li><a href="../insights/ai-visibility-score.html">Insights -&gt; Visibility Score</a></li>
+<li><a href="../insights/share-of-voice.html">Insights -&gt; Share of Voice</a></li>
+</ul>
+<p>These pages explain how citations and brand mentions are converted into measurable visibility insights.</p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/introduction/how-genezio-measures-visibility.html
+++ b/new-landing/public/docs/introduction/how-genezio-measures-visibility.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>How Genezio Measures Visibility | Genezio Docs</title>
+  <meta name="description" content="How Genezio Measures Visibility in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="active" href="how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>How Genezio Measures Visibility</h1>
+<p>Genezio measures <strong>AI Visibility</strong> by analyzing how often a brand appears in answers generated by AI systems during simulated conversations. The most important signal Genezio tracks is <strong>AI Recommendations</strong> — whether the brand is actively recommended as a solution by answer engines. AI Visibility measures the broader presence: how often your brand appears in AI answers at all, whether as a mention, comparison, or recommendation.</p>
+<p>At its core, the visibility metric answers a simple question:</p>
+<p><strong>In how many AI conversations does your brand appear?</strong></p>
+<p>Visibility is therefore expressed as a <strong>percentage of conversations where the brand is mentioned</strong>.</p>
+<hr />
+<h2>The Visibility Formula</h2>
+<p>AI Visibility is calculated as:</p>
+<pre><code>Visibility = (Conversations where the brand appears / Total eligible conversations) x 100</code></pre>
+<p>If a brand appears in 42 out of 100 conversations analyzed by Genezio, its AI Visibility for that set of scenarios is:</p>
+<pre><code>42%</code></pre>
+<p>This percentage provides a clear view of how frequently the brand appears when AI systems answer questions related to a specific topic.</p>
+<hr />
+<h2>What Counts as a Brand Appearance</h2>
+<p>A brand is considered visible in a conversation when the AI assistant:</p>
+<ul>
+<li>explicitly mentions the brand</li>
+<li>includes the brand in a recommendation list</li>
+<li>compares the brand with competitors</li>
+<li>references the brand as part of an explanation</li>
+</ul>
+<p>The brand does not need to be the main focus of the answer. Any clear mention of the brand counts as visibility for that conversation.</p>
+<hr />
+<h2>Genezio Agent Types</h2>
+<p>Genezio runs different types of conversations to simulate realistic interactions with AI systems.</p>
+<p>These Genezio Agent types represent different user intents.</p>
+<h3>Prompter Agent</h3>
+<p>A <strong>Prompter Agent</strong> conversation simulates a user asking an open-ended question about a category.</p>
+<p>Example:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>What CRM should a startup use?</strong></em></p></blockquote>
+<p>The AI assistant responds by recommending or listing relevant products.</p>
+<p>Prompter Agent conversations are one of the primary signals used to measure visibility because they reflect how brands appear when users ask general discovery questions.</p>
+<hr />
+<h3>Recommender Agent</h3>
+<p>A <strong>Recommender Agent</strong> conversation simulates a user explicitly asking the AI to recommend solutions.</p>
+<p>Example:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>Recommend project management tools for small teams.</strong></em></p></blockquote>
+<p>These conversations are also used to calculate visibility because they reveal which brands AI systems recommend in response to common requests.</p>
+<hr />
+<h3>Introspector Agent</h3>
+<p>An <strong>Introspector Agent</strong> conversation asks the AI system about a specific brand.</p>
+<p>Example:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>What is HubSpot used for?</strong></em></p></blockquote>
+<p>Because the brand name is included in the question, the AI assistant will almost always mention the brand in its answer.</p>
+<p>For this reason, Introspector Agent conversations are <strong>not used when calculating AI Visibility</strong>.</p>
+<p>Including them would artificially inflate the visibility score.</p>
+<hr />
+<h3>Comparer Agent</h3>
+<p>A <strong>Comparer Agent</strong> conversation asks the AI system to compare specific brands.</p>
+<p>Example:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>HubSpot vs Pipedrive: which CRM is better for startups?</strong></em></p></blockquote>
+<p>In this type of conversation, the brands appear in the prompt itself.</p>
+<p>Because the model will almost always reference those brands in the response, Comparer Agent conversations are <strong>excluded from KPI calculations</strong>. The Comparer is a competitive analysis tool — it uses your brand-level metrics to show how you stack up against specific rivals, but it does not contribute to the calculation of AI Visibility or AI Recommendations.</p>
+<hr />
+<h2>Which Agent Types Generate KPIs</h2>
+<table>
+<thead><tr><th style="text-align:left">Agent</th><th style="text-align:left">Generates KPIs?</th><th style="text-align:left">Role</th></tr></thead>
+<tbody>
+<tr><td style="text-align:left"><strong>Prompter</strong></td><td style="text-align:left">✓ AI Visibility</td><td style="text-align:left">Open-ended discovery — AI chooses which brands to mention</td></tr>
+<tr><td style="text-align:left"><strong>Recommender</strong></td><td style="text-align:left">✓ AI Recommendations + Visibility</td><td style="text-align:left">Scenario-driven — AI chooses which brands to recommend</td></tr>
+<tr><td style="text-align:left"><strong>Introspector</strong></td><td style="text-align:left">—</td><td style="text-align:left">Narrative analysis — explores how AI describes your brand</td></tr>
+<tr><td style="text-align:left"><strong>Comparer</strong></td><td style="text-align:left">—</td><td style="text-align:left">Competitive analysis — compares your brand against specific rivals</td></tr>
+</tbody>
+</table>
+<p>Both KPIs are <strong>brand-level metrics</strong> generated from Prompter and Recommender conversations, where the AI decides on its own which brands to surface. This ensures the metrics reflect organic brand presence and genuine recommendation decisions.</p>
+<hr />
+<h2>Visibility Across Topics</h2>
+<p>Visibility is typically measured within the context of a <strong>specific topic or scenario set</strong>.</p>
+<p>For example, a brand might have:</p>
+<ul>
+<li>60% visibility for &quot;CRM for startups&quot;</li>
+<li>35% visibility for &quot;sales tools for small businesses&quot;</li>
+<li>10% visibility for &quot;marketing automation platforms&quot;</li>
+</ul>
+<p>This helps organizations identify where their brand is strongly associated with a topic and where visibility is limited.</p>
+<hr />
+<h2>Why Visibility Is a Useful Metric</h2>
+<p>AI Visibility provides a high-level signal about how AI systems perceive a brand within a category.</p>
+<p>A higher visibility score suggests that:</p>
+<ul>
+<li>the brand is frequently associated with the topic</li>
+<li>the brand appears in recommendations</li>
+<li>the brand is commonly referenced in the sources used by AI systems</li>
+</ul>
+<p>A lower score may indicate that competitors dominate the conversation or that the brand is underrepresented in the information sources used by AI models.</p>
+<hr />
+<h2>Next Steps</h2>
+<p>To understand how visibility compares with competitors, continue with:</p>
+<ul>
+<li><a href="../insights/share-of-voice.html">Insights -&gt; Share of Voice</a></li>
+<li><a href="../insights/ai-visibility-score.html">Insights -&gt; Visibility Score</a></li>
+</ul>
+<p>These pages explain how Genezio expands visibility analysis into deeper competitive insights.</p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/introduction/how-llm-search-works.html
+++ b/new-landing/public/docs/introduction/how-llm-search-works.html
@@ -1,0 +1,203 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>How LLM Search Works | Genezio Docs</title>
+  <meta name="description" content="How LLM Search Works in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="active" href="how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>How LLM Search Works</h1>
+<p>answer engines such as ChatGPT, Claude, Gemini, and Perplexity answer questions differently from traditional search engines.</p>
+<p>Instead of returning a list of links, these systems generate an AI-generated answer by retrieving information from multiple sources and combining it into a single response.</p>
+<p>Understanding how this process works helps explain why certain brands, sources, and claims appear in AI-generated answers.</p>
+<hr />
+<h2>The Traditional Search Model</h2>
+<p>In traditional search engines, the interaction usually follows this pattern:</p>
+<ol>
+<li>A user enters a search query.</li>
+<li>The search engine retrieves pages from its index.</li>
+<li>Pages are ranked according to relevance and authority.</li>
+<li>The user selects one or more links to visit.</li>
+</ol>
+<p>Visibility is therefore determined by <strong>ranking position</strong> and <strong>click-through rate</strong>.</p>
+<hr />
+<h2>The Answer Engine Search Model</h2>
+<p>AI-engine-powered systems follow a different process.</p>
+<p>Instead of returning links, they generate a direct answer based on information retrieved from multiple sources.</p>
+<p>A simplified flow looks like this:</p>
+<ol>
+<li>The user asks a question.</li>
+<li>The AI system expands the query into multiple related searches.</li>
+<li>Relevant documents and sources are retrieved.</li>
+<li>The model combines information from those sources.</li>
+<li>A natural language answer is generated.</li>
+<li>Some systems include citations or links to sources.</li>
+</ol>
+<p>Because the final answer is AI-generated, visibility is determined by <strong>whether a brand or source is included in the generated response</strong>, not only whether its webpage ranks highly.</p>
+<hr />
+<h2>Step 1: The User Question</h2>
+<p>The process begins when a user asks a question in natural language.</p>
+<p>Examples:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>What are the best running shoes for marathon training?</strong></em></p></blockquote>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>Which CRM is best for startups?</strong></em></p></blockquote>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>What is the best ski resort in Switzerland for beginners?</strong></em></p></blockquote>
+<p>Unlike traditional keyword search, these questions are often longer and more conversational.</p>
+<hr />
+<h2>Step 2: Query Expansion</h2>
+<p>answer engines rarely rely on the original question alone.</p>
+<p>Instead, they expand it into several related queries to gather more information. These expanded searches are often referred to as <strong>follow-up searches (called query fanouts)</strong>.</p>
+<p>For example, the question:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>What are the best running shoes for marathon training?</strong></em></p></blockquote>
+<p>may internally expand into queries such as:</p>
+<ul>
+<li>best marathon running shoes</li>
+<li>long distance running shoes reviews</li>
+<li>nike vs adidas marathon shoes</li>
+<li>top marathon racing shoes</li>
+</ul>
+<p>This process allows the AI system to explore multiple perspectives and retrieve a broader set of sources.</p>
+<hr />
+<h2>Step 3: Retrieval of Sources</h2>
+<p>The system then retrieves information from various sources on the web.</p>
+<p>These sources may include:</p>
+<ul>
+<li>brand websites</li>
+<li>editorial articles</li>
+<li>product reviews</li>
+<li>comparison pages</li>
+<li>forums and communities</li>
+<li>news sites</li>
+</ul>
+<p>The retrieved documents provide the factual material used to generate the final answer.</p>
+<hr />
+<h2>Step 4: Synthesis</h2>
+<p>After retrieving relevant information, the model analyzes and combines it.</p>
+<p>Rather than quoting a single page, the model may merge information from several sources to produce a coherent explanation.</p>
+<p>For example, an answer might include:</p>
+<ul>
+<li>a list of recommended products</li>
+<li>summaries of key advantages</li>
+<li>comparisons between alternatives</li>
+</ul>
+<p>This synthesis step is one of the main differences between AI-generated answers and traditional search results.</p>
+<hr />
+<h2>Step 5: Answer Generation</h2>
+<p>Finally, the model produces a natural language response.</p>
+<p>An answer might look like this:</p>
+<blockquote><p>Popular marathon running shoes include the Nike Alphafly, Adidas Adios Pro, and Saucony Endorphin Elite due to their energy return and lightweight design.</p></blockquote>
+<p>Depending on the system, the response may also include:</p>
+<ul>
+<li>links to sources</li>
+<li>citations</li>
+<li>follow-up suggestions</li>
+<li>additional context</li>
+</ul>
+<hr />
+<h2>Why This Matters for Visibility</h2>
+<p>Because answer engines generate an AI-generated answer, users may interact primarily with the response itself rather than clicking through multiple links.</p>
+<p>This means that visibility depends on:</p>
+<ul>
+<li>whether a brand is mentioned</li>
+<li>whether its website is cited</li>
+<li>whether it appears in comparisons or recommendations</li>
+</ul>
+<p>A brand can therefore have strong search rankings but limited presence in AI answers if it is rarely referenced or associated with the topic.</p>
+<hr />
+<h2>What This Means for Organizations</h2>
+<p>Organizations that want to appear in AI-generated answers need to understand how answer engines gather and combine information.</p>
+<p>Important factors include:</p>
+<ul>
+<li>how clearly a brand is associated with a topic</li>
+<li>whether authoritative sources reference the brand</li>
+<li>whether the brand&#39;s own content answers common user questions</li>
+<li>how competitors are represented in the same category</li>
+</ul>
+<p>Because AI-engine answers are generated from multiple sources, visibility depends on a broader web presence rather than a single optimized page.</p>
+<hr />
+<h2>How Genezio Analyzes This Process</h2>
+<p>Genezio helps teams understand how answer engine search works in practice.</p>
+<p>It does this by:</p>
+<ul>
+<li>running realistic conversations with AI systems</li>
+<li>extracting the queries the model explores</li>
+<li>identifying the sources used in answers</li>
+<li>detecting brand mentions and citations</li>
+<li>comparing visibility across competitors</li>
+</ul>
+<p>This allows organizations to observe how AI systems interpret their category and how their brand appears within those answers.</p>
+<hr />
+<h2>Next Steps</h2>
+<p>To continue learning about how AI systems retrieve and use information, see:</p>
+<ul>
+<li><a href="./query-fanouts-explained.html">Introduction -&gt; Query Fanouts Explained</a></li>
+<li><a href="../core-concepts/citations.html">Core Concepts -&gt; Citations</a></li>
+<li><a href="../core-concepts/perceptions.html">Core Concepts -&gt; Perceptions</a></li>
+</ul>
+<p>These pages explain how Genezio extracts structured insights from AI-generated answers.</p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/introduction/how-llms-select-sources.html
+++ b/new-landing/public/docs/introduction/how-llms-select-sources.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>How LLMs Select Sources | Genezio Docs</title>
+  <meta name="description" content="How LLMs Select Sources in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="active" href="how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>How LLMs Select Sources</h1>
+<p>When an AI system such as ChatGPT, Claude, Gemini, or Perplexity answers a question, it typically relies on information retrieved from multiple sources on the web.</p>
+<p>These sources provide the factual material that the model uses to generate its response. Understanding how these sources are selected helps explain why certain websites, brands, or claims appear in AI-generated answers.</p>
+<hr />
+<h2>Retrieval Before Generation</h2>
+<p>Most modern AI search systems follow a pattern where <strong>the answer engine pulls in and uses sources to build its answer</strong>.</p>
+<p>In this process:</p>
+<ol>
+<li>A user asks a question.</li>
+<li>The system retrieves relevant documents or passages.</li>
+<li>The answer engine analyzes the retrieved information.</li>
+<li>The model generates an AI-generated answer.</li>
+</ol>
+<p>Because the model uses retrieved information as context, the documents selected during the retrieval stage strongly influence the final answer.</p>
+<hr />
+<h2>Where Sources Come From</h2>
+<p>AI systems typically retrieve information from a combination of sources, including:</p>
+<ul>
+<li>websites indexed by search engines</li>
+<li>editorial articles</li>
+<li>product reviews</li>
+<li>comparison pages</li>
+<li>documentation sites</li>
+<li>forums and communities</li>
+<li>training data and web sources</li>
+</ul>
+<p>Some systems rely on external search engines, while others use their own internal indexes or knowledge sources.</p>
+<hr />
+<h2>Factors That Influence Source Selection</h2>
+<p>Several factors influence which sources are retrieved when answering a question.</p>
+<h3>Relevance to the Query</h3>
+<p>The most important factor is whether the content is relevant to the question or related queries generated by the system.</p>
+<p>If a page clearly answers a specific question, it is more likely to be retrieved.</p>
+<h3>Authority and Trust</h3>
+<p>Sources that are widely recognized as authoritative may be prioritized.</p>
+<p>These may include:</p>
+<ul>
+<li>well-known publications</li>
+<li>established websites</li>
+<li>industry experts</li>
+<li>frequently cited resources</li>
+</ul>
+<p>Authority signals can come from links, citations, reputation, and historical reliability.</p>
+<h3>Content Clarity</h3>
+<p>Content that clearly explains a topic or provides structured information is often easier for AI systems to interpret and use.</p>
+<p>For example, pages that include:</p>
+<ul>
+<li>clear headings</li>
+<li>lists</li>
+<li>comparisons</li>
+<li>concise explanations</li>
+</ul>
+<p>may be more easily incorporated into generated answers.</p>
+<h3>Coverage of the Topic</h3>
+<p>Sources that comprehensively cover a topic are more likely to be retrieved.</p>
+<p>If a page addresses multiple related questions or provides deep explanations, it may be selected more frequently than a page that only mentions the topic briefly.</p>
+<h3>Consistency Across Sources</h3>
+<p>If multiple sources repeat similar claims or mention the same brands, the AI system may treat those signals as stronger evidence when generating its answer.</p>
+<hr />
+<h2>How Sources Influence AI Answers</h2>
+<p>Once relevant documents are retrieved, the model uses them as context to generate its response.</p>
+<p>During this stage, the model may:</p>
+<ul>
+<li>summarize information from multiple sources</li>
+<li>compare products or services</li>
+<li>merge explanations from different documents</li>
+<li>extract key facts or recommendations</li>
+</ul>
+<p>Because the answer is AI-generated, the final response may not match any single page exactly. Instead, it reflects a combination of information gathered during retrieval.</p>
+<hr />
+<h2>Citations in AI Answers</h2>
+<p>Some AI systems include citations or links that indicate which sources influenced the response.</p>
+<p>These citations may point to:</p>
+<ul>
+<li>articles</li>
+<li>documentation pages</li>
+<li>product pages</li>
+<li>review sites</li>
+</ul>
+<p>Citations help users verify where information came from and provide transparency about the sources used to generate the answer.</p>
+<hr />
+<h2>Why Source Selection Matters for Brands</h2>
+<p>Because AI systems build answers from retrieved sources, brands that appear frequently in those sources are more likely to appear in AI-generated responses.</p>
+<p>This means that visibility in AI answers depends on:</p>
+<ul>
+<li>being mentioned by relevant sources</li>
+<li>having content that answers common questions</li>
+<li>appearing in comparisons and reviews</li>
+<li>being associated with the topic across the web</li>
+</ul>
+<p>If a brand rarely appears in the sources retrieved for a topic, it may have limited visibility in AI-generated answers.</p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/introduction/how-the-5-agents-work.html
+++ b/new-landing/public/docs/introduction/how-the-5-agents-work.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>How the 5 Agents Work | Genezio Docs</title>
+  <meta name="description" content="How the 5 Agents Work in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="active" href="how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>How the 5 Agents Work</h1>
+<p><em>Genezio runs five types of AI conversations to understand your brand&#39;s presence. Each type answers a different question — and not all of them count toward your score. Here&#39;s why that&#39;s a feature, not a limitation.</em></p>
+<blockquote><p><strong>Think of it like this:</strong> Imagine hiring five different mystery shoppers to evaluate your brand. Each one walks into a store (or asks an AI) with a different brief. The results they bring back reveal very different things about how you&#39;re perceived.</p></blockquote>
+<hr />
+<h2>Agent 1: Prompter Agent</h2>
+<p><strong>Counts toward: AI Visibility %</strong></p>
+<p><strong>What it simulates:</strong> A user at the top of the funnel — exploring a category, not yet committed to any brand. They ask open-ended discovery questions.</p>
+<p><strong>Example queries:</strong></p>
+<ul>
+<li>&quot;What are the best CRM tools for a startup?&quot;</li>
+<li>&quot;What software should I use for project management?&quot;</li>
+<li>&quot;What tools do marketing teams use for analytics?&quot;</li>
+</ul>
+<p><strong>Why it matters for you:</strong> This is how most buyers start their research. If you&#39;re absent here, you&#39;re being filtered out before the shortlist even forms. Prompter conversations are the biggest driver of AI Visibility %.</p>
+<p><strong>Content implication:</strong> Category pillar pages · &quot;Best of&quot; content · In-depth guides · Original research</p>
+<hr />
+<h2>Agent 2: Recommender Agent</h2>
+<p><strong>Counts toward: AI Recommendations % and AI Visibility %</strong></p>
+<p><strong>What it simulates:</strong> A user ready to make a decision. They&#39;ve done some research and now they want the AI to pick something specific for their situation. These are often multi-step conversations.</p>
+<p><strong>Example queries:</strong></p>
+<ul>
+<li>&quot;I&#39;m a solo founder with a team of 3. Recommend a CRM that&#39;s easy to set up and under $50/month.&quot;</li>
+<li>&quot;What&#39;s the best project management tool for a remote design team of 10?&quot;</li>
+</ul>
+<p><strong>Why it matters for you:</strong> This is the highest-intent moment in the AI buyer journey. If a user asks AI to recommend something and your name doesn&#39;t come up, you&#39;ve lost a qualified lead. AI Recommendations % is your conversion metric.</p>
+<p><strong>Content implication:</strong> Use-case landing pages · Persona-specific content · ROI calculators</p>
+<hr />
+<h2>Agent 3: Introspector Agent</h2>
+<p><strong>Does not count toward KPIs</strong></p>
+<p><strong>What it simulates:</strong> A user who already knows your brand and wants to learn more. They ask the AI directly about you by name.</p>
+<p><strong>Example queries:</strong></p>
+<ul>
+<li>&quot;What is HubSpot?&quot;</li>
+<li>&quot;What does Salesforce do?&quot;</li>
+<li>&quot;Tell me about Notion&#39;s pricing model.&quot;</li>
+</ul>
+<p><strong>Why it doesn&#39;t count toward your score:</strong> If the user mentions your brand in the question, the AI will almost always mention it in the answer — that&#39;s not meaningful. Including these would artificially inflate your Visibility score and make it useless as a benchmark.</p>
+<p><strong>What it&#39;s useful for instead:</strong> Understanding how AI describes your brand. What claims does it make? Are those claims accurate? This feeds directly into your Perceptions analysis — the accuracy layer underneath the score.</p>
+<p><strong>Content implication:</strong> Brand narrative analysis · Claim accuracy monitoring · Positioning audit</p>
+<hr />
+<h2>Agent 4: Comparer Agent</h2>
+<p><strong>Does not count toward KPIs — this is a competitive analysis tool</strong></p>
+<p><strong>What it simulates:</strong> A user actively evaluating you against a specific competitor. They&#39;ve narrowed their options and want a head-to-head verdict.</p>
+<p><strong>Example queries:</strong></p>
+<ul>
+<li>&quot;HubSpot vs Pipedrive: which is better for a startup?&quot;</li>
+<li>&quot;Notion vs Asana for a remote team?&quot;</li>
+<li>&quot;Should I use Salesforce or HubSpot?&quot;</li>
+</ul>
+<p><strong>Why it doesn&#39;t count toward your score:</strong> Both brands are named in the question, so both will always appear in the answer. Like the Introspector, including these would distort your metrics.</p>
+<p><strong>What it&#39;s actually for:</strong> The Comparer is an <strong>analysis tool</strong>. It takes the brand-level KPIs that Genezio has already calculated from Prompter and Recommender conversations and puts them in competitive context. It also runs head-to-head AI conversations to reveal how answer engines frame you against specific competitors — what strengths it highlights, what weaknesses it mentions, and who it picks as the better fit.</p>
+<p>Think of it this way: Prompter and Recommender tell you <em>your score</em>. Comparer tells you <em>why you&#39;re winning or losing against a specific rival</em>.</p>
+<p><strong>Content implication:</strong> Competitive intelligence · &quot;vs&quot; comparison page strategy · Win/loss narrative</p>
+<hr />
+<h2>Agent 5: Fact Checker Agent</h2>
+<p><strong>Does not count toward KPIs — this is an accuracy measurement tool</strong></p>
+<p><strong>What it simulates:</strong> A factual probe. Instead of asking the answer engine open-ended questions, you give it specific verifiable claims about your brand (pricing, features, founding year, customer counts, certifications) and measure whether it confirms, contradicts, or dodges each one.</p>
+<p><strong>Example claims:</strong></p>
+<ul>
+<li>&quot;Our product offers a free tier.&quot;</li>
+<li>&quot;We were founded in 2019.&quot;</li>
+<li>&quot;We are SOC 2 Type II certified.&quot;</li>
+</ul>
+<p><strong>Per-claim outcomes:</strong></p>
+<ul>
+<li><strong>True</strong> — the engine confirms the claim</li>
+<li><strong>False</strong> — the engine contradicts the claim</li>
+<li><strong>Indecisive</strong> — the engine doesn&#39;t take a clear position</li>
+</ul>
+<p><strong>Why it doesn&#39;t count toward your score:</strong> The claims are stated in the prompt, so the conversation isn&#39;t measuring discovery. It&#39;s measuring accuracy — a different axis from visibility and recommendation.</p>
+<p><strong>What it&#39;s actually for:</strong> Fact Checker is most useful for brands where factual accuracy directly affects buyer trust or regulatory standing — security, financial services, healthcare, regulated industries. It also pairs with the <a href="../core-concepts/knowledge-base.html">Knowledge Base</a> and <a href="../core-concepts/perceptions.html">Grounded Perceptions</a> to form a complete accuracy stack: KB defines truth, Fact Checker actively tests whether answer engines confirm it, Grounded Perceptions show whether engines spontaneously match it.</p>
+<p><strong>Content implication:</strong> Update product/pricing/certification pages so the right facts are public and crawlable · Correct third-party listings · Publish authoritative reference content for high-risk claims</p>
+<p>See <a href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a> for the full feature page.</p>
+<hr />
+<h2>Quick Reference Summary</h2>
+<table>
+<thead><tr><th style="text-align:left">Agent</th><th style="text-align:left">User Intent</th><th style="text-align:left">Brand Named?</th><th style="text-align:left">Role</th><th style="text-align:left">Best Used For</th></tr></thead>
+<tbody>
+<tr><td style="text-align:left"><strong>Prompter</strong></td><td style="text-align:left">Exploring a category</td><td style="text-align:left">No</td><td style="text-align:left">✓ Measures AI Visibility</td><td style="text-align:left">Awareness measurement</td></tr>
+<tr><td style="text-align:left"><strong>Recommender</strong></td><td style="text-align:left">Ready to decide</td><td style="text-align:left">No</td><td style="text-align:left">✓ Measures AI Recommendations + Visibility</td><td style="text-align:left">Intent measurement</td></tr>
+<tr><td style="text-align:left"><strong>Introspector</strong></td><td style="text-align:left">Learning about a brand</td><td style="text-align:left">Yes</td><td style="text-align:left">Narrative analysis (not KPIs)</td><td style="text-align:left">Narrative &amp; accuracy audit</td></tr>
+<tr><td style="text-align:left"><strong>Comparer</strong></td><td style="text-align:left">Comparing options</td><td style="text-align:left">Yes (both)</td><td style="text-align:left">Competitive analysis (not KPIs)</td><td style="text-align:left">Competitive positioning</td></tr>
+<tr><td style="text-align:left"><strong>Fact Checker</strong></td><td style="text-align:left">Verifying specific claims</td><td style="text-align:left">Yes</td><td style="text-align:left">Accuracy measurement (not KPIs)</td><td style="text-align:left">Hallucination &amp; factual monitoring</td></tr>
+</tbody>
+</table>
+<blockquote><p><strong>Two agents measure. Three agents analyze.</strong> Prompter and Recommender generate your KPIs. Introspector, Comparer, and Fact Checker help you understand the narratives, competitive dynamics, and factual accuracy behind those numbers. All five are essential — but they play different roles.</p></blockquote>
+<hr />
+<p><em>Next: <a href="from-data-to-content-strategy.html">From Data to Content Strategy</a></em></p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/introduction/query-fanouts-explained.html
+++ b/new-landing/public/docs/introduction/query-fanouts-explained.html
@@ -1,0 +1,173 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Query Fanouts Explained | Genezio Docs</title>
+  <meta name="description" content="Query Fanouts Explained in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="how-llm-search-works.html">How LLM Search Works</a></li><li><a class="active" href="query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Query Fanouts Explained</h1>
+<p>When a user asks a question to an AI system such as ChatGPT, Claude, Gemini, or Perplexity, the model rarely relies on the exact question alone to generate an answer.</p>
+<p>Instead, the system expands the original question into multiple related searches in order to gather more information. These expanded searches are called <strong>follow-up searches (called query fanouts)</strong>.</p>
+<p>Query fanouts help the AI system explore a topic from several angles, retrieve more relevant sources, and generate a more complete answer.</p>
+<hr />
+<h2>What Is a Query Fanout?</h2>
+<p>A <strong>query fanout</strong> is an additional search query generated internally by the AI system to support answering the user&#39;s question.</p>
+<p>Rather than searching for a single phrase, the system produces several variations and related questions that help it gather information from different sources.</p>
+<p>For example, a user might ask:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>What are the best running shoes for marathon training?</strong></em></p></blockquote>
+<p>The AI system may internally generate queries such as:</p>
+<ul>
+<li>best marathon running shoes</li>
+<li>long distance running shoe reviews</li>
+<li>nike vs adidas marathon shoes</li>
+<li>best racing shoes for marathon runners</li>
+<li>top cushioned marathon shoes</li>
+</ul>
+<p>These queries allow the system to retrieve content covering different perspectives on the topic.</p>
+<hr />
+<h2>Why Answer Engines Use Query Fanouts</h2>
+<p>User questions are often broad, ambiguous, or incomplete. A single search query may not retrieve enough information to generate a high-quality answer.</p>
+<p>Query fanouts help the AI system:</p>
+<ul>
+<li>explore multiple interpretations of a question</li>
+<li>retrieve information from different sources</li>
+<li>compare alternatives</li>
+<li>validate claims across several documents</li>
+</ul>
+<p>By expanding the search space, the model can build a more comprehensive understanding of the topic before generating its response.</p>
+<hr />
+<h2>How Query Fanouts Influence Answers</h2>
+<p>The fanout queries determine which documents and sources are retrieved during the information gathering step.</p>
+<p>Those sources then influence:</p>
+<ul>
+<li>which brands appear in the answer</li>
+<li>which sources are cited</li>
+<li>what claims are included</li>
+<li>how competitors are compared</li>
+</ul>
+<p>For example, if a fanout query includes:</p>
+<blockquote class="query-fanout"><p><strong>Query fanout:</strong> <em><strong>best CRM for startups 2024</strong></em></p></blockquote>
+<p>The AI system may retrieve comparison pages, review articles, and vendor websites discussing startup CRMs. The brands mentioned in those sources are therefore more likely to appear in the final answer.</p>
+<p>This means that <strong>query fanouts strongly influence AI Recommendations and Visibility</strong>.</p>
+<hr />
+<h2>Example of Query Fanouts in Practice</h2>
+<p>Consider the question:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>Which CRM is best for startups?</strong></em></p></blockquote>
+<p>Possible fanout queries may include:</p>
+<ul>
+<li><strong>Query fanout:</strong> <em>best CRM software for startups</em></li>
+<li><strong>Query fanout:</strong> <em>HubSpot vs Pipedrive for small businesses</em></li>
+<li><strong>Query fanout:</strong> <em>affordable CRM tools for startups</em></li>
+<li><strong>Query fanout:</strong> <em>startup sales management software</em></li>
+<li><strong>Query fanout:</strong> <em>CRM comparison for early stage companies</em></li>
+</ul>
+<p>Each of these searches may retrieve different articles, reviews, or vendor pages. The information gathered from those sources is then combined into a single answer.</p>
+<hr />
+<h2>Why Query Fanouts Matter for Brands</h2>
+<p>Because fanout queries determine which sources are retrieved, they also influence which brands appear in AI-generated answers.</p>
+<p>If a brand is frequently mentioned in sources related to those fanout queries, it is more likely to appear in the final response.</p>
+<p>If a brand is absent from those sources, it may not appear in the answer even if it is a strong product in the category.</p>
+<p>Understanding query fanouts therefore helps organizations identify:</p>
+<ul>
+<li>what questions AI systems explore when answering a topic</li>
+<li>which sources influence the answer</li>
+<li>where their brand is missing from the information landscape</li>
+</ul>
+<hr />
+<h2>How Genezio Uses Query Fanouts</h2>
+<p>Genezio extracts and analyzes query fanouts generated during AI conversations.</p>
+<p>This allows teams to understand:</p>
+<ul>
+<li>what the AI system is actually searching for</li>
+<li>which queries drive source retrieval</li>
+<li>which topics influence brand visibility</li>
+<li>where new content opportunities exist</li>
+</ul>
+<p>For example, if Genezio detects that AI systems frequently explore queries such as:</p>
+<ul>
+<li>&quot;best CRM for early stage startups&quot;</li>
+<li>&quot;CRM tools for SaaS founders&quot;</li>
+</ul>
+<p>but a brand has little content or coverage around those topics, that gap may represent an opportunity to improve AI Recommendations and Visibility.</p>
+<hr />
+<h2>Query Fanouts vs Keywords</h2>
+<p>Query fanouts are similar to keywords but reflect how AI systems explore a topic rather than how users type short search queries.</p>
+<p>Traditional SEO often focuses on optimizing pages for individual keywords.</p>
+<p>In AI-powered search, understanding the broader set of fanout queries can be more important because these queries determine which sources are retrieved during answer generation.</p>
+<hr />
+<h2>Next Steps</h2>
+<p>To learn how fanout queries influence AI answers, continue with:</p>
+<ul>
+<li><a href="../core-concepts/citations.html">Core Concepts -&gt; Citations</a></li>
+<li><a href="../core-concepts/perceptions.html">Core Concepts -&gt; Perceptions</a></li>
+<li><a href="../insights/ai-visibility-score.html">Insights -&gt; Visibility Score</a></li>
+</ul>
+<p>These pages explain how Genezio analyzes AI responses and transforms them into structured insights.</p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/introduction/what-is-genezio.html
+++ b/new-landing/public/docs/introduction/what-is-genezio.html
@@ -1,0 +1,206 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>What is Genezio? | Genezio Docs</title>
+  <meta name="description" content="What is Genezio? in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="active" href="what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>What is Genezio?</h1>
+<p>Genezio is a platform that helps organizations measure and improve how often answer engines like ChatGPT, Claude, Gemini, and Perplexity <strong>recommend their brand</strong> when users ask for solutions.</p>
+<p>As more users rely on AI assistants to research products, compare services, and make purchasing decisions, being recommended in AI-generated answers is becoming as important as ranking on Google.</p>
+<p>Genezio helps teams measure their AI recommendation rate, understand what drives it, and take action to improve it.</p>
+<h2>The Shift from Search Engines to AI Answers</h2>
+<p>Traditionally, users discovered brands through search engines such as Google.</p>
+<p>The typical interaction looked like this:</p>
+<ol>
+<li>A user enters a search query.</li>
+<li>The search engine returns a list of links.</li>
+<li>The user clicks one or more results.</li>
+</ol>
+<p>In AI-powered search, the experience is different.</p>
+<p>Instead of showing a list of links, the AI system generates a direct answer based on information retrieved from multiple sources.</p>
+<p>Example:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>What are the best running shoes for marathon training?</strong></em></p></blockquote>
+<p>Instead of displaying links, the AI assistant may produce an answer like:</p>
+<blockquote class="ai-answer"><p><strong>AI answer:</strong> The best running shoes for marathon training include the Nike Alphafly, Adidas Adios Pro, and Saucony Endorphin Elite due to their energy return and cushioning.</p></blockquote>
+<p>The sources used to generate this answer may include:</p>
+<ul>
+<li>product review sites</li>
+<li>ecommerce stores</li>
+<li>brand websites</li>
+<li>forums and communities</li>
+<li>editorial articles</li>
+</ul>
+<p>In this environment, what matters is whether the AI system <strong>recommends your brand</strong> when users ask for a solution — not just whether you appear in a list of search results.</p>
+<h2>AI Recommendations and Visibility</h2>
+<p>Genezio measures two things:</p>
+<ol>
+<li><strong>AI Recommendations %</strong> — How often answer engines actively recommend your brand when users ask for a solution. This is the primary metric — it&#39;s the closest thing to a buying decision in AI search.</li>
+<li><strong>AI Visibility %</strong> — How often your brand appears at all in AI-generated answers (mentioned, cited, or compared). This is the broader measure of your brand&#39;s AI presence.</li>
+</ol>
+<p>For example, if a user asks:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>What is the best CRM for startups?</strong></em></p></blockquote>
+<p>An AI assistant might answer:</p>
+<blockquote class="ai-answer"><p><strong>AI answer:</strong> For a startup, I&#39;d recommend HubSpot for its free tier and ease of setup. Salesforce and Pipedrive are also worth considering if you need more customization.</p></blockquote>
+<p>In this scenario:</p>
+<ul>
+<li><strong>HubSpot is recommended</strong> — it&#39;s the AI&#39;s suggested choice.</li>
+<li>HubSpot, Salesforce, and Pipedrive all have <strong>visibility</strong> — they appear in the answer.</li>
+<li>Any CRM not mentioned has neither recommendations nor visibility for this conversation.</li>
+</ul>
+<p>Genezio helps you measure both metrics across thousands of AI conversations, and shows you what to do to get recommended more often.</p>
+<h2>How Genezio Works</h2>
+<p>At a high level, Genezio simulates real user interactions with AI systems and analyzes the responses.</p>
+<p>The process includes several steps.</p>
+<h3>1. Define Topics</h3>
+<p>Topics represent the areas where a brand wants to appear in AI-generated answers.</p>
+<p>Examples:</p>
+<ul>
+<li>&quot;running shoes for marathon training&quot;</li>
+<li>&quot;best CRM for startups&quot;</li>
+<li>&quot;luxury ski resorts in Switzerland&quot;</li>
+</ul>
+<h3>2. Create Scenarios</h3>
+<p>Scenarios represent realistic user prompts that someone might ask an AI assistant.</p>
+<p>Example scenario:</p>
+<blockquote class="user-question"><p><strong>User query:</strong> <em><strong>I am training for my first marathon. What running shoes should I buy?</strong></em></p></blockquote>
+<h3>3. Run Conversations</h3>
+<p>Genezio runs conversations with supported answer engines such as:</p>
+<ul>
+<li>ChatGPT</li>
+<li>Claude</li>
+<li>Gemini</li>
+<li>Perplexity</li>
+</ul>
+<p>Each conversation simulates a real user asking questions and sometimes asking follow-up questions.</p>
+<h3>4. Analyze the Answers</h3>
+<p>The platform then analyzes each response to extract structured information, including:</p>
+<ul>
+<li>brands mentioned</li>
+<li>sources cited</li>
+<li>claims (perceptions) about each brand</li>
+<li>accuracy of those claims against your brand knowledge</li>
+</ul>
+<h3>5. Generate Insights</h3>
+<p>Using this data, Genezio calculates metrics and generates insights such as:</p>
+<ul>
+<li>AI Recommendations and Visibility scores</li>
+<li>share of voice compared to competitors</li>
+<li>most cited sources</li>
+<li>opportunities for content improvements</li>
+</ul>
+<h2>What Genezio Measures</h2>
+<p>Genezio analyzes several aspects of AI-generated answers.</p>
+<h3>Brand Mentions</h3>
+<p>How often a brand appears in responses generated by AI assistants.</p>
+<h3>Citations</h3>
+<p>Which sources the AI system references when generating answers.</p>
+<p>These may include:</p>
+<ul>
+<li>brand websites</li>
+<li>review sites</li>
+<li>news articles</li>
+<li>blogs</li>
+</ul>
+<h3>Competitor Presence</h3>
+<p>Which other brands appear in the same answers.</p>
+<p>This helps identify competitors in the AI landscape.</p>
+<h3>Perception Accuracy</h3>
+<p>Whether claims AI makes about a brand are correct or incorrect — evaluated against your brand knowledge base. This helps you identify where answer engines are misrepresenting your brand and where they are getting it right.</p>
+<h3>Share of Voice</h3>
+<p>The relative visibility of a brand compared to competitors across many AI conversations.</p>
+<h2>Why This Matters</h2>
+<p>AI assistants are becoming a common starting point for product discovery and purchasing decisions.</p>
+<p>Users increasingly ask questions like:</p>
+<ul>
+<li>&quot;What CRM should a startup use?&quot;</li>
+<li>&quot;Recommend running shoes for marathon training.&quot;</li>
+<li>&quot;What is the best credit card for travel?&quot;</li>
+</ul>
+<p>The brands that answer engines recommend in these answers gain a direct pipeline advantage. If your competitor is recommended and you&#39;re not, you&#39;re losing deals before the buyer even visits your website.</p>
+<p>Genezio helps you understand this new landscape and take action to get recommended more.</p>
+<h2>What Genezio Does Not Do</h2>
+<p>Genezio does not control how AI systems generate answers.</p>
+<p>Instead, it helps organizations:</p>
+<ul>
+<li>measure how often their brand is recommended in AI responses</li>
+<li>understand why certain brands get recommended over others</li>
+<li>identify opportunities to improve their recommendation rate</li>
+</ul>
+<p>Improvements to AI recommendations typically come from better content, stronger authority signals, and greater relevance across the web.</p>
+<h2>Next Steps</h2>
+<p>To start using Genezio, continue with:</p>
+<ul>
+<li><a href="../getting-started.html">Getting Started</a></li>
+<li><a href="../core-concepts/topics.html">Core Concepts -&gt; Topics</a></li>
+<li><a href="../core-concepts/scenarios.html">Core Concepts -&gt; Scenarios</a></li>
+</ul>
+<p>These sections explain how to set up your first AI recommendations analysis.</p>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/introduction/what-kpis-are-we-measuring.html
+++ b/new-landing/public/docs/introduction/what-kpis-are-we-measuring.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>What KPIs Are We Measuring | Genezio Docs</title>
+  <meta name="description" content="What KPIs Are We Measuring in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="what-is-genezio.html">What is Genezio?</a></li><li><a class="" href="why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="active" href="what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>What KPIs Are We Measuring</h1>
+<p>In Genezio, two core KPIs are used to evaluate how your brand performs in AI-generated answers:</p>
+<ul>
+<li>AI Recommendations</li>
+<li>AI Visibility</li>
+</ul>
+<p>These KPIs answer different questions and should be read together.</p>
+<hr />
+<h2>AI Recommendations</h2>
+<p><strong>AI Recommendations</strong> is a percentage.</p>
+<p>It measures how often your brand is actively recommended in conversations where it appeared. The denominator is conversations where your brand was visible — making this a <strong>conversion rate from presence to recommendation</strong>.</p>
+<p>AI Recommendations helps you understand whether answer engines trust your brand enough to suggest it as a solution when users ask for one.</p>
+<hr />
+<h2>AI Visibility</h2>
+<p><strong>AI Visibility</strong> is a percentage.</p>
+<p>It measures the percentage of eligible conversations where your brand appears in AI-generated answers.</p>
+<p>This includes cases where your brand is:</p>
+<ul>
+<li>mentioned</li>
+<li>listed in recommendations</li>
+<li>included in comparisons</li>
+</ul>
+<p>AI Visibility gives a broader view of how often your brand is present in AI answers across relevant conversations.</p>
+<hr />
+<h2>Where These KPIs Come From</h2>
+<p>Both metrics are <strong>brand-level measurements</strong>, calculated from Prompter and Recommender conversations — the two agent types where the AI chooses which brands to surface on its own.</p>
+<p>The Comparer and Introspector agents serve different purposes. The Comparer is a <strong>competitive analysis tool</strong> that uses your brand&#39;s metrics to show how you stack up against specific competitors. The Introspector analyzes how AI describes your brand. Neither contributes to the calculation of AI Recommendations or AI Visibility.</p>
+<hr />
+<h2>How These KPIs Work Together</h2>
+<p>Use both metrics together:</p>
+<ul>
+<li><strong>AI Recommendations</strong> tells you how often answer engines actively recommend your brand when it appears in a conversation.</li>
+<li><strong>AI Visibility</strong> tells you how often your brand appears at all in eligible conversations.</li>
+</ul>
+<p>A brand may have high visibility but a lower recommendation rate, or the opposite. Reading both KPIs together gives a more complete view of AI performance.</p>
+<hr />
+<h2>Next Steps</h2>
+<p>To understand where these KPIs come from, continue with:</p>
+<ul>
+<li><a href="../core-concepts/brand-recommendation.html">Core Concepts -&gt; Brand Recommendation</a></li>
+<li><a href="../core-concepts/brand-visibility.html">Core Concepts -&gt; Brand Visibility</a></li>
+<li><a href="../core-concepts/topic-scenario-relevance.html">Core Concepts -&gt; Topic / Scenario Relevance</a></li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>

--- a/new-landing/public/docs/introduction/why-ai-recommendations-matter.html
+++ b/new-landing/public/docs/introduction/why-ai-recommendations-matter.html
@@ -1,0 +1,155 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Why AI Recommendations Matter | Genezio Docs</title>
+  <meta name="description" content="Why AI Recommendations Matter in Genezio documentation" />
+  <meta name="robots" content="index,follow" />
+  <link rel="stylesheet" href="../assets/site.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="../index.html">Genezio Docs</a>
+      <nav aria-label="Top navigation"></nav>
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Open menu">&#9776;</button>
+    </div>
+  </header>
+  <div class="sidebar-overlay" id="sidebar-overlay"></div>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation navigation">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Genezio Docs</span>
+      <hr style="border:none;border-top:1px solid var(--line);margin:12px 0 0" />
+    </div>
+    <div class="sidebar-nav">
+      
+      <section class="nav-group">
+        <h3><a class="" href="../getting-started/setup-guide.html">Getting Started</a></h3>
+        <ul><li><a class="" href="../getting-started/setup-guide.html">Setup Guide</a></li><li><a class="" href="../getting-started/sign-in-and-sso-options.html">Sign-in and SSO Options</a></li><li><a class="" href="../getting-started/describe-your-brand.html">Describe Your Brand</a></li><li><a class="" href="../getting-started/create-scenarios.html">Create Scenarios</a></li><li><a class="" href="../getting-started/generating-personas-from-documents.html">Generating Personas from Documents</a></li><li><a class="" href="../getting-started/customizing-your-dashboard.html">Customizing Your Dashboard</a></li><li><a class="" href="../getting-started/topic-tags.html">Topic Tags</a></li><li><a class="" href="../getting-started/your-first-week.html">Your First Week</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="active" href="what-is-genezio.html">Introduction</a></h3>
+        <ul><li><a class="" href="what-is-genezio.html">What is Genezio?</a></li><li><a class="active" href="why-ai-recommendations-matter.html">Why AI Recommendations Matter</a></li><li><a class="" href="how-llm-search-works.html">How LLM Search Works</a></li><li><a class="" href="query-fanouts-explained.html">Query Fanouts Explained</a></li><li><a class="" href="how-llms-select-sources.html">How LLMs Select Sources</a></li><li><a class="" href="how-ai-citations-work.html">How AI Citations Work</a></li><li><a class="" href="what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a></li><li><a class="" href="how-genezio-measures-visibility.html">How Genezio Measures Visibility</a></li><li><a class="" href="how-the-5-agents-work.html">How the 5 Agents Work</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../core-concepts/brands.html">Core Concepts</a></h3>
+        <ul><li><a class="" href="../core-concepts/brands.html">Brands</a></li><li><a class="" href="../core-concepts/brand-recommendation.html">Brand Recommendation</a></li><li><a class="" href="../core-concepts/brand-visibility.html">Brand Visibility</a></li><li><a class="" href="../core-concepts/users.html">Users</a></li><li><a class="" href="../core-concepts/personas.html">Personas</a></li><li><a class="" href="../core-concepts/topics.html">Topics</a></li><li><a class="" href="../core-concepts/scenarios.html">Scenarios</a></li><li><a class="" href="../core-concepts/topic-scenario-relevance.html">Topic / Scenario Relevance</a></li><li><a class="" href="../core-concepts/conversations.html">Conversations</a></li><li><a class="" href="../core-concepts/query-fanouts.html">Query Fanouts</a></li><li><a class="" href="../core-concepts/citations.html">Citations</a></li><li><a class="" href="../core-concepts/perceptions.html">Perceptions</a></li><li><a class="" href="../core-concepts/competitors.html">Competitors</a></li><li><a class="" href="../core-concepts/knowledge-base.html">Knowledge Base</a></li><li><a class="" href="../core-concepts/products.html">Products</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../genezio-agents/prompter-agent.html">Genezio Agents</a></h3>
+        <ul><li><a class="" href="../genezio-agents/prompter-agent.html">Prompter Agent</a></li><li><a class="" href="../genezio-agents/recommender-agent.html">Recommender Agent</a></li><li><a class="" href="../genezio-agents/introspector-agent.html">Introspector Agent</a></li><li><a class="" href="../genezio-agents/comparer-agent.html">Comparer Agent</a></li><li><a class="" href="../genezio-agents/fact-checker-agent.html">Fact Checker Agent</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../analysis/creating-scenarios.html">Running Conversations</a></h3>
+        <ul><li><a class="" href="../analysis/creating-scenarios.html">Creating Scenarios</a></li><li><a class="" href="../analysis/selecting-answer-engines.html">Selecting Answer Engines</a></li><li><a class="" href="../analysis/running-conversations.html">Running Conversations</a></li><li><a class="" href="../analysis/playground.html">Playground</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></h3>
+        <ul><li><a class="" href="../geo-assistant/geo-assistant.html">Geo Assistant</a></li><li><a class="" href="../geo-assistant/send-to-geo.html">Send to Geo</a></li><li><a class="" href="../geo-assistant/sessions-and-history.html">Sessions and History</a></li><li><a class="" href="../geo-assistant/actions-geo-can-take.html">Actions Geo Can Take</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce</a></h3>
+        <ul><li><a class="" href="../agentic-commerce/agentic-commerce-readiness.html">Agentic Commerce Readiness</a></li><li><a class="" href="../agentic-commerce/ucp-readiness-audit.html">UCP Readiness Audit</a></li></ul>
+      </section><section class="nav-group">
+        <h3><a class="" href="../integrations/cdn-log-integration.html">Integrations</a></h3>
+        <ul><li><a class="" href="../integrations/cdn-log-integration.html">CDN Log Integration</a></li></ul>
+      </section>
+      <section class="nav-group">
+        <h3>Actions</h3>
+        <ul><li><a class="" href="../insights/your-kpis-explained.html">Your KPIs Explained</a></li><li><a class="" href="../insights/ai-perception-summary.html">AI Perception Summary</a></li><li><a class="" href="../insights/share-of-voice.html">Share of Voice</a></li><li><a class="" href="../insights/swot-analysis.html">SWOT Analysis</a></li><li><a class="" href="../insights/actionable-insights.html">Actionable Insights</a></li><li><a class="" href="../content-hub/content-hub.html">Content Hub</a></li><li><a class="" href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a></li><li><a class="" href="../content-hub/briefs.html">Briefs</a></li><li><a class="" href="../content-hub/content-analysis.html">Content Analysis</a></li><li><a class="" href="../content-hub/editing-articles.html">Editing Articles</a></li></ul>
+      </section>
+    </div>
+  </aside>
+    <main class="content" id="main-content">
+      <h1>Why AI Recommendations Matter</h1>
+<p><em>For CMOs, content strategists, SEO leads, and digital marketing managers.</em></p>
+<blockquote><p><strong>The one-sentence version:</strong> If your brand isn&#39;t recommended when the right customer asks the right question to an AI assistant, you&#39;ve already lost that deal — before the buyer ever visits your website.</p></blockquote>
+<hr />
+<h2>How People Actually Use AI Assistants</h2>
+<p>Let&#39;s start with what really happens when someone uses ChatGPT, Claude, Gemini, or Perplexity to make a buying decision.</p>
+<p>It&#39;s not a single question. It&#39;s a conversation.</p>
+<p>A marketing director looking for a CRM doesn&#39;t just type <em>&quot;best CRM&quot;</em> and accept the first answer. The interaction looks more like this:</p>
+<blockquote><p><strong>Turn 1:</strong> <em>&quot;I need a CRM for a B2B startup with a 10-person sales team.&quot;</em></p></blockquote>
+<blockquote><p><strong>Turn 2:</strong> <em>&quot;We need something under $50/month per seat with good HubSpot integration.&quot;</em></p></blockquote>
+<blockquote><p><strong>Turn 3:</strong> <em>&quot;Between Pipedrive and Close, which one is better for outbound-heavy teams?&quot;</em></p></blockquote>
+<p>With each turn, the AI narrows its recommendations. Brands enter and leave the conversation. By the final answer, the AI has recommended one or two brands — and dismissed the rest.</p>
+<p>This is where deals are won or lost in AI search.</p>
+<hr />
+<h2>Not Every Recommendation Is Equal</h2>
+<p>Here&#39;s what marketers need to understand: a recommendation only matters when it happens in the right context.</p>
+<p>Being recommended as <em>&quot;a good CRM&quot;</em> in response to a generic prompt is nice. Being recommended as <em>&quot;the best CRM for outbound-heavy B2B teams under $50/seat&quot;</em> — when that&#39;s exactly your target customer — is what moves pipeline.</p>
+<p>That&#39;s why Genezio doesn&#39;t test your brand against random questions. Every conversation in Genezio is built around:</p>
+<ul>
+<li><strong>A persona</strong> — who is asking (their role, industry, company size, location, language)</li>
+<li><strong>A scenario</strong> — what they need (their specific constraints, budget, use case)</li>
+<li><strong>A multi-step conversation</strong> — how the AI&#39;s recommendation evolves as the persona adds detail</li>
+</ul>
+<p>This means your AI Recommendations % reflects how well your brand performs with the customers you actually want to reach, in the situations that actually matter to your business.</p>
+<hr />
+<h2>The Two Things You Need to Know</h2>
+<p><strong>If your brand is not recommended, you lose the opportunity.</strong></p>
+<p>This is the clearest signal in AI search. When a persona who matches your ideal customer asks an AI assistant for a recommendation in your category — and the AI doesn&#39;t mention you — that buyer is now considering your competitors. There is no second page. There is no &quot;scroll down.&quot; You simply weren&#39;t in the conversation.</p>
+<p><strong>If your brand is recommended in the right scenario, you gain influence.</strong></p>
+<p>When the AI recommends your brand to the right persona, with the right constraints, in a realistic multi-step conversation — that&#39;s meaningful. It means the AI considers your brand a credible match for that buyer&#39;s specific needs. And because AI assistants are increasingly where buying journeys start, that recommendation carries real weight.</p>
+<hr />
+<h2>Why Context Changes Everything</h2>
+<p>Consider two conversations:</p>
+<p><strong>Conversation A:</strong> <em>&quot;What are some CRM tools?&quot;</em> The AI lists 8 brands alphabetically. Your brand is one of them.</p>
+<p><strong>Conversation B:</strong> <em>&quot;I run a 15-person SaaS sales team. We do mostly outbound. I need a CRM under $50/seat that integrates with our existing email stack. What should I use?&quot;</em> The AI recommends your brand as the top choice, with a specific explanation of why it fits.</p>
+<p>Both count as a &quot;mention.&quot; But only Conversation B is a recommendation — and only Conversation B reflects a real buying moment.</p>
+<p>Genezio focuses on Conversation B. Every conversation is tied to a persona and scenario that mirrors how your actual customers ask questions. This is what makes the AI Recommendations % meaningful — it measures whether your brand wins in the moments that matter, not whether it appears in generic lists.</p>
+<hr />
+<h2>What Genezio Measures — and How</h2>
+<p>Genezio runs thousands of AI conversations, each built from a persona and scenario you define. Here&#39;s how the measurement works:</p>
+<ol>
+<li><strong>You define your audience</strong> — who your customers are, where they&#39;re located, what language they speak</li>
+<li><strong>You define your topics</strong> — the categories where you want to be recommended</li>
+<li><strong>Genezio creates realistic scenarios</strong> — multi-step conversations that reflect real buyer questions with real constraints</li>
+<li><strong>answer engines respond</strong> — ChatGPT, Claude, Gemini, and Perplexity each answer independently</li>
+<li><strong>Genezio analyzes every response</strong> — who was recommended, who was mentioned, what sources were cited, and what the AI said about each brand</li>
+</ol>
+<p>The result is two numbers:</p>
+<ul>
+<li><strong>AI Recommendations %</strong> — Of the conversations where your brand appeared, how often were you actively recommended as a solution? This is your conversion metric.</li>
+<li><strong>AI Visibility %</strong> — How often does your brand appear at all across eligible conversations? This is your presence metric.</li>
+</ul>
+<p>Together, they tell you: <em>are you showing up, and when you do, are you winning?</em></p>
+<hr />
+<h2>The Old World vs. The New World</h2>
+<table>
+<thead><tr><th style="text-align:left"></th><th style="text-align:left">Traditional Search (SEO)</th><th style="text-align:left">AI Search (GEO)</th></tr></thead>
+<tbody>
+<tr><td style="text-align:left"><strong>How it works</strong></td><td style="text-align:left">User searches → gets links → clicks yours</td><td style="text-align:left">User has a conversation with AI → AI recommends a brand</td></tr>
+<tr><td style="text-align:left"><strong>What drives results</strong></td><td style="text-align:left">Page ranking and click-through rate</td><td style="text-align:left">Whether AI recommends your brand for that persona&#39;s specific needs</td></tr>
+<tr><td style="text-align:left"><strong>The risk</strong></td><td style="text-align:left">Page 2 gets no traffic</td><td style="text-align:left">There is no page 2 — you&#39;re either recommended or you&#39;re not</td></tr>
+</tbody>
+</table>
+<blockquote><p><strong>Key insight:</strong> A brand can rank #1 on Google for &quot;best project management tool&quot; and still be completely absent from ChatGPT&#39;s recommendation when a real buyer describes their situation. These are two separate games — and most brands are only playing one of them.</p></blockquote>
+<hr />
+<h2>What You Can Do With Genezio</h2>
+<p><strong>See where you&#39;re being recommended — and where you&#39;re not</strong> Your AI Recommendations % is broken down by topic, persona, and answer engine. You can see exactly which scenarios you win and which ones your competitors take.</p>
+<p><strong>Understand why competitors get recommended instead of you</strong> Genezio shows which sources answer engines cite when they recommend competitors. That&#39;s your content gap — and your content roadmap.</p>
+<p><strong>Know exactly what content to create</strong> Actionable Insights surfaces specific recommendations: which topics to target, which sources to get cited by, which narratives to build — all tied to the personas and scenarios where you&#39;re losing.</p>
+<p><strong>Track improvements over time</strong> As you publish new content, improve your site, or earn new mentions, your scores update. You can see the direct impact of your marketing work on AI recommendations for the audiences that matter.</p>
+<p><strong>Benchmark against competitors</strong> See your Share of Voice — how often your brand is recommended compared to competitors across the same personas and scenarios. A single number your CMO can track every month.</p>
+<blockquote><p><strong>For CMOs:</strong> AI Recommendations % and Share of Voice are the two numbers to put on your monthly marketing dashboard. They tell you whether your brand is winning the conversations that drive pipeline.</p></blockquote>
+<hr />
+<h2>What to Read Next</h2>
+<ul>
+<li><a href="what-kpis-are-we-measuring.html">What KPIs Are We Measuring</a> — Deep dive into AI Recommendations % and AI Visibility %</li>
+<li><a href="how-the-5-agents-work.html">How the 5 Agents Work</a> — The four types of AI conversations Genezio runs, and why each matters</li>
+<li><a href="../content-hub/from-data-to-content-strategy.html">From Data to Content Strategy</a> — How to turn Genezio insights into a content plan</li>
+<li><a href="../getting-started/your-first-week.html">Your First Week</a> — A practical day-by-day guide to getting started</li>
+</ul>
+    </main>
+  </div>
+  <script>
+    (function(){
+      var sb=document.querySelector('.sidebar'),ov=document.getElementById('sidebar-overlay'),btn=document.getElementById('sidebar-toggle'),cls=document.getElementById('sidebar-close');
+      var scrollY=0;
+      function open(){scrollY=window.scrollY;document.body.style.top='-'+scrollY+'px';sb.classList.add('open');ov.classList.add('open');document.body.classList.add('sidebar-open');}
+      function close(){sb.classList.remove('open');ov.classList.remove('open');document.body.classList.remove('sidebar-open');document.body.style.top='';window.scrollTo(0,scrollY);}
+      btn.addEventListener('click',open);
+      ov.addEventListener('click',close);
+      if(cls)cls.addEventListener('click',close);
+      sb.addEventListener('click',function(e){if(e.target.tagName==='A')close();});
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## What
Seeds `new-landing/public/docs/` with the built **Genezio product docs**, so `genezio.com/docs/` serves real content. Vercel auto-deploys on merge.

Pairs with #551 (which removed the legacy `/docs` → deployapps.dev redirect). With that redirect already gone from `main`, `/docs` currently 404s — merging this fixes it.

## URLs
- `genezio.com/docs/` → redirects to the introduction page
- `genezio.com/docs/<section>/<page>.html` (e.g. `/docs/core-concepts/perceptions.html`)
- assets at `genezio.com/docs/assets/`

## Ongoing updates
Future doc changes are synced automatically: a GitHub Action in [Genez-io/docs](https://github.com/Genez-io/docs) rebuilds and pushes into this folder on every push to its `main` (requires the `LANDING_REPO_TOKEN` secret on the docs repo). This PR is the one-time initial seed; later the Action keeps it current (no-op if unchanged).