### PR TITLE
Redirect /docs -> /docs/ (fix docs CSS on no-slash URL)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,11 @@
   "outputDirectory": "new-landing/dist",
   "redirects": [
     {
+      "source": "/docs",
+      "destination": "/docs/",
+      "permanent": false
+    },
+    {
       "source": "/:path*",
       "has": [
         {


### PR DESCRIPTION
## Problem
Visiting `genezio.com/docs` (no trailing slash) loads the docs landing **without CSS**. Vercel serves the `/docs` directory index directly (HTTP 200, no redirect), so the page's *relative* asset paths resolve against `/` — e.g. `assets/site.css` becomes `/assets/site.css` (404) instead of `/docs/assets/site.css`. Deep pages are unaffected because they end in `.html`.

## Fix
Add a redirect `/docs` -> `/docs/` in `vercel.json` so the browser lands on the canonical trailing-slash URL, where relative paths resolve correctly. One entry, no other redirects touched.