### PR TITLE
DPA: align remaining clauses with the signed 18 August 2026 PDF

### DIFF
--- a/new-landing/src/polymet/pages/data-processing-agreement.tsx
+++ b/new-landing/src/polymet/pages/data-processing-agreement.tsx
@@ -120,7 +120,7 @@ export function DataProcessingAgreement() {
                   protection laws require one.
                 </p>
 
-                <Section>Section 1.</Section>
+                <Section>Section 1. General provisions</Section>
 
                 <Clause number="Clause 1." title="Purpose and scope" />
                 <Item label="(a)">
@@ -163,8 +163,8 @@ export function DataProcessingAgreement() {
                 <Item label="(b)">
                   <p>
                     This DPA shall be read and interpreted in the light of the provisions of the
-                    Applicable Data Protection Legislation. This DPA is subject to and an integral
-                    part of the Main Agreement.
+                    Applicable Data Protection Legislation. This DPA forms an integral part of the
+                    Main Agreement and, in case of conflict, Clause 3 (Hierarchy) shall apply.
                   </p>
                 </Item>
 
@@ -215,8 +215,8 @@ export function DataProcessingAgreement() {
                 <SubClause number="6.1" title="Instructions" />
                 <Item label="(a)">
                   <p>
-                    The processor shall process personal data on documented instructions from the
-                    controller, unless required to do so by the Applicable Data Protection Legislation
+                    The processor shall process personal data only on documented instructions from
+                    the controller, unless required to do so by the Applicable Data Protection Legislation
                     to which the processor is subject, including those provided in the Annexes
                     hereunder. In this case, the processor shall inform the controller of that legal
                     requirement before processing, unless the law prohibits this on important grounds
@@ -372,7 +372,8 @@ export function DataProcessingAgreement() {
                 <Item label="(a)">
                   <p>
                     The processor shall notify the controller of any request it has received from the
-                    data subject.
+                    data subject. It shall not respond to the request itself, unless authorised to do
+                    so by the controller.
                   </p>
                 </Item>
                 <Item label="(b)">
@@ -430,8 +431,9 @@ export function DataProcessingAgreement() {
                 </Item>
                 <Item label="(b)">
                   <p>
-                    in obtaining the following information which, pursuant to the Applicable Data
-                    Protection Legislation, shall be stated in the controller’s notification
+                    in obtaining the information which, pursuant to Article 33(3) of the GDPR and any
+                    other Applicable Data Protection Legislation, must be stated in the
+                    controller’s notification;
                   </p>
                 </Item>
                 <Item label="(c)">
@@ -684,7 +686,7 @@ export function DataProcessingAgreement() {
                   <div className="p-6 rounded-lg border space-y-6">
                     <div>
                       <h4 className="font-semibold">
-                        Technical and organisational measures implemented by the processor
+                        1. Technical and organisational measures implemented by the processor
                       </h4>
                       <ul className="list-disc pl-6 mt-4 space-y-2">
                         <li>
@@ -763,8 +765,8 @@ export function DataProcessingAgreement() {
                     </div>
                     <div>
                       <h4 className="font-semibold">
-                        Description of the specific technical and organisational measures to be
-                        taken by the processor to be able to provide assistance to the controller:
+                        2. Description of the specific technical and organisational measures to
+                        be taken by the processor to be able to provide assistance to the controller:
                       </h4>
                       <p className="mt-4">
                         Processor has implemented the technical and organisational measures
@@ -774,8 +776,8 @@ export function DataProcessingAgreement() {
                     </div>
                     <div>
                       <h4 className="font-semibold">
-                        For transfers to (sub-)processors, also describe the specific technical and
-                        organisational measures to be taken by the (sub-)processor to be able to
+                        3. For transfers to (sub-)processors, also describe the specific technical
+                        and organisational measures to be taken by the (sub-)processor to be able to
                         provide assistance to the controller:
                       </h4>
                       <p className="mt-4">


### PR DESCRIPTION
The DPA page was already largely at the 18 August 2026 version (header date, sub-processor list, Annex II/III, backup retention, ISO 27001 / SOC 2, Trust Center link). Comparing it clause by clause against the signed PDF, a handful of passages still carried wording from the previous version.

## Changes

| Location | Change |
|---|---|
| Section 1 | Restore the full title — "Section 1. **General provisions**" |
| Clause 2 (b) | "is subject to and an integral part of the Main Agreement" → "**forms an integral part of the Main Agreement and, in case of conflict, Clause 3 (Hierarchy) shall apply**" |
| Clause 6.1 (a) | The processor processes personal data "**only** on documented instructions" |
| Clause 7 (a) | Add the missing sentence: "It shall not respond to the request itself, unless authorised to do so by the controller." |
| Clause 8.1 (b) | Cite **Article 33(3) of the GDPR** and use the mandatory "**must** be stated" |
| Annex III | Restore the 1. / 2. / 3. numbering that item 2 refers back to |

Text only — the existing design is untouched: same `Section`/`Clause`/`SubClause`/`Item` components, the two-column numbering layout, the annex cards and the sub-processor table.

## Verification

`tsc --noEmit` reports no errors in this file. The 30 errors it does report are pre-existing on `dev` (`components/ui/calendar.tsx`, `resizable.tsx`, `sonner.tsx` and others), untouched here.

## Note for review

In the PDF, Annex III item 1 opens with a stray quotation mark (`"Technical and organisational measures…`) that is never closed. I left it out of the page, assuming it is a drafting slip in the document rather than intended text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)