### PR TITLE
Blog: make in-text links visible (emerald + underline)

### DIFF
--- a/new-landing/public/rss.xml
+++ b/new-landing/public/rss.xml
@@ -5,7 +5,7 @@
     <link>https://genezio.com/blog/</link>
     <description>The platform built for Generative Search and Answer Engine Optimization.</description>
     <language>en-us</language>
-    <lastBuildDate>Mon, 24 Aug 2026 14:30:40 GMT</lastBuildDate>
+    <lastBuildDate>Mon, 24 Aug 2026 14:37:30 GMT</lastBuildDate>
     <atom:link href="https://genezio.com/rss.xml" rel="self" type="application/rss+xml" />
     
     <item>

--- a/new-landing/src/polymet/pages/blog-post.tsx
+++ b/new-landing/src/polymet/pages/blog-post.tsx
@@ -780,7 +780,7 @@ export function BlogPost() {
                       {...props}
                       target={isExternal ? "_blank" : undefined}
                       rel={isExternal ? "noopener noreferrer" : undefined}
-                      className="text-zinc-400 hover:text-zinc-300 transition-colors break-all"
+                      className="text-emerald-400 underline underline-offset-2 decoration-emerald-400/40 hover:text-emerald-300 hover:decoration-emerald-400 transition-colors break-words"
                     />
                   );
                 }


### PR DESCRIPTION
In-text links in blog posts rendered as `text-zinc-400` with no underline, which is dimmer than the `text-white/80` body text — so anchors were indistinguishable from plain text and appeared "lost."

This styles anchors with the brand emerald accent and an underline, so links are clearly clickable. Applies to all blog posts (shared renderer). Verified the Enterprise Buyer's Checklist post now renders all 21 in-text links as visible anchors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmfAfNKnLE9VKhFLuaCYdH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmfAfNKnLE9VKhFLuaCYdH)_