### PR TITLE
Blog: links same color as text, underline only

### DIFF
--- a/new-landing/public/rss.xml
+++ b/new-landing/public/rss.xml
@@ -5,7 +5,7 @@
     <link>https://genezio.com/blog/</link>
     <description>The platform built for Generative Search and Answer Engine Optimization.</description>
     <language>en-us</language>
-    <lastBuildDate>Mon, 24 Aug 2026 14:37:30 GMT</lastBuildDate>
+    <lastBuildDate>Mon, 24 Aug 2026 14:40:24 GMT</lastBuildDate>
     <atom:link href="https://genezio.com/rss.xml" rel="self" type="application/rss+xml" />
     
     <item>

--- a/new-landing/src/polymet/pages/blog-post.tsx
+++ b/new-landing/src/polymet/pages/blog-post.tsx
@@ -780,7 +780,7 @@ export function BlogPost() {
                       {...props}
                       target={isExternal ? "_blank" : undefined}
                       rel={isExternal ? "noopener noreferrer" : undefined}
-                      className="text-emerald-400 underline underline-offset-2 decoration-emerald-400/40 hover:text-emerald-300 hover:decoration-emerald-400 transition-colors break-words"
+                      className="underline underline-offset-2 decoration-white/40 hover:decoration-white/80 transition-colors break-words"
                     />
                   );
                 }


### PR DESCRIPTION
Per feedback: in-text blog links should keep the body text color and just be underlined (no emerald). Anchors now inherit the surrounding `text-white/80` color with an underline that brightens on hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmfAfNKnLE9VKhFLuaCYdH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmfAfNKnLE9VKhFLuaCYdH)_