### PR TITLE
Blog: add inline hero image to the two latest posts

### DIFF
--- a/new-landing/public/rss.xml
+++ b/new-landing/public/rss.xml
@@ -5,7 +5,7 @@
     <link>https://genezio.com/blog/</link>
     <description>The platform built for Generative Search and Answer Engine Optimization.</description>
     <language>en-us</language>
-    <lastBuildDate>Wed, 26 Aug 2026 15:25:12 GMT</lastBuildDate>
+    <lastBuildDate>Wed, 26 Aug 2026 15:29:57 GMT</lastBuildDate>
     <atom:link href="https://genezio.com/rss.xml" rel="self" type="application/rss+xml" />
     
     <item>
@@ -171,6 +171,15 @@
         <enclosure url="https://genezio.com/images/genezio-release-content-hub.webp" type="image/webp" length="0" />
     </item>
     <item>
+        <title><![CDATA[Marketing Agency Brand Presence in the Age of AI Search]]></title>
+        <link>https://genezio.com/blog/marketing-agency-brand-presence-ai-search/</link>
+        <guid isPermaLink="true">https://genezio.com/blog/marketing-agency-brand-presence-ai-search/</guid>
+        <description><![CDATA[Discover why AI brand presence matters for marketing agencies in 2026 and how to leverage AI visibility tools like Genezio to master generative search.]]></description>
+        <pubDate>Mon, 02 Mar 2026 00:00:00 GMT</pubDate>
+        <author>Paula Cionca</author>
+        <enclosure url="https://genezio.com/images/marketing-agency-brand-presence-ai-search.webp" type="image/webp" length="0" />
+    </item>
+    <item>
         <title><![CDATA[Mastering Brand Presence in 2026: AI-Powered Measurement Tools]]></title>
         <link>https://genezio.com/blog/mastering-company-brand-presence/</link>
         <guid isPermaLink="true">https://genezio.com/blog/mastering-company-brand-presence/</guid>
@@ -178,15 +187,6 @@
         <pubDate>Mon, 02 Mar 2026 00:00:00 GMT</pubDate>
         <author>Paula Cionca</author>
         <enclosure url="https://genezio.com/images/mastering-company-brand-presence-2026.webp" type="image/webp" length="0" />
-    </item>
-    <item>
-        <title><![CDATA[Marketing Agency Brand Presence in the Age of AI Search]]></title>
-        <link>https://genezio.com/blog/marketing-agency-brand-presence-ai-search/</link>
-        <guid isPermaLink="true">https://genezio.com/blog/marketing-agency-brand-presence-ai-search/</guid>
-        <description><![CDATA[Discover why AI brand presence matters for marketing agencies in 2026 and how to leverage AI visibility tools like Genezio to master generative search.]]></description>
-        <pubDate>Sun, 01 Mar 2026 22:00:00 GMT</pubDate>
-        <author>Paula Cionca</author>
-        <enclosure url="https://genezio.com/images/marketing-agency-brand-presence-ai-search.webp" type="image/webp" length="0" />
     </item>
     <item>
         <title><![CDATA[Genezio vs Semrush: What marketing agencies need to know]]></title>

--- a/new-landing/src/posts/ai-mentions-arent-random.md
+++ b/new-landing/src/posts/ai-mentions-arent-random.md
@@ -23,6 +23,8 @@ readTime: 7
 url: /ai-mentions-arent-random/
 ---
 
+![AI Mentions Aren't Random: The Content and Source Signals Behind Brand Visibility](/images/ai-mentions-arent-random.webp)
+
 If your brand shows up in ChatGPT, Google AI Overviews, Perplexity, Claude, or Copilot, that visibility rarely happens by accident. AI mentions are usually the result of two forces working together: **what models already know from training data** and **what answer engines can retrieve, read, and cite from the live web today**.
 
 For marketing leaders, that distinction matters. A brand may be well known in model memory yet still lose high-intent recommendations because its current content is weak, inaccessible, or too promotional to quote. Just as often, a lesser-known competitor earns the citation because it published a clearer comparison, a stronger proof point, or a more machine-readable page.

--- a/new-landing/src/posts/enterprise-buyers-checklist-ai-visibility-platforms-2026.md
+++ b/new-landing/src/posts/enterprise-buyers-checklist-ai-visibility-platforms-2026.md
@@ -23,6 +23,8 @@ readTime: 11
 url: /enterprise-buyers-checklist-ai-visibility-platforms-2026/
 ---
 
+![Enterprise Buyer's Checklist for AI Visibility Platforms in 2026](/images/enterprise-buyers-checklist-ai-visibility-platforms-2026.webp)
+
 For enterprise procurement, the best AI visibility platform is the one that clears security review, supports identity controls, and can be operationalized across brands and markets. In 2026, that means evaluating far more than dashboards or AI search visibility claims. You need a vendor that can survive security, legal, IT, finance, and procurement scrutiny—and still deliver actionable brand visibility generative AI intelligence once deployed.
 
 Genezio positions itself as an [enterprise AI visibility platform](https://genezio.com/) built for procurement-to-production deployment, with publicly visible controls including SOC 2 Type II (an independent audit of security controls), ISO 27001 (an information security management standard), CSA STAR Level 1 (a cloud security assurance registry), GDPR compliance, SSO/SAML (single sign-on via enterprise identity systems), SCIM provisioning (automated user and access provisioning), role-based access, audit logs, data residency, and API + MCP access. That combination matters because enterprise AI visibility measurement is no longer just a marketing software purchase; it is a governed enterprise SaaS decision.


### PR DESCRIPTION
The two latest posts were missing the inline hero image at the top of the body that older posts have (e.g. best-geo-tools, genezio-vs-peec). Added it to both, referencing each post's existing thumbnail:

- `ai-mentions-arent-random`
- `enterprise-buyers-checklist-ai-visibility-platforms-2026`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmfAfNKnLE9VKhFLuaCYdH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmfAfNKnLE9VKhFLuaCYdH)_