### PR TITLE
Blog post: sticky left TOC, softer body text, blue links

### DIFF
--- a/new-landing/public/rss.xml
+++ b/new-landing/public/rss.xml
@@ -5,7 +5,7 @@
     <link>https://genezio.com/blog/</link>
     <description>The platform built for Generative Search and Answer Engine Optimization.</description>
     <language>en-us</language>
-    <lastBuildDate>Wed, 26 Aug 2026 15:29:57 GMT</lastBuildDate>
+    <lastBuildDate>Wed, 26 Aug 2026 15:43:16 GMT</lastBuildDate>
     <atom:link href="https://genezio.com/rss.xml" rel="self" type="application/rss+xml" />
     
     <item>

--- a/new-landing/src/polymet/pages/blog-post.tsx
+++ b/new-landing/src/polymet/pages/blog-post.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { HeroEyebrow } from "@/polymet/components/hero-eyebrow";
 import { Button } from "@/components/ui/button";
 import { useParams, Navigate, useLocation } from "react-router";
@@ -15,6 +15,98 @@ import {
 import { getPostById, getAllPosts, getPostPath } from "@/lib/posts";
 import { authors } from "@/lib/authors";
 import { BlogPostTypeBadge } from "@/polymet/components/blog-post-type-badge";
+
+/** Slugify heading text into a stable anchor id. */
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+}
+
+/** Flatten React children (markdown-rendered heading) into plain text. */
+function nodeToText(children: React.ReactNode): string {
+  if (children == null || children === false) return "";
+  if (typeof children === "string" || typeof children === "number")
+    return String(children);
+  if (Array.isArray(children)) return children.map(nodeToText).join("");
+  if (React.isValidElement(children))
+    return nodeToText((children.props as { children?: React.ReactNode }).children);
+  return "";
+}
+
+/** Extract H2 headings (the "main sections") from markdown for the table of contents. */
+function extractH2Headings(markdown: string): { id: string; text: string }[] {
+  const out: { id: string; text: string }[] = [];
+  let inCode = false;
+  for (const line of markdown.split("\n")) {
+    if (line.trim().startsWith("```")) {
+      inCode = !inCode;
+      continue;
+    }
+    if (inCode) continue;
+    const m = line.match(/^##\s+(.+?)\s*$/);
+    if (m) {
+      const text = m[1].replace(/\*\*/g, "").replace(/`/g, "").trim();
+      out.push({ id: slugify(text), text });
+    }
+  }
+  return out;
+}
+
+/** Sticky in-page table of contents with scroll-spy, shown in the left gutter. */
+function TableOfContents({
+  headings,
+}: {
+  headings: { id: string; text: string }[];
+}) {
+  const [active, setActive] = useState<string>(headings[0]?.id ?? "");
+
+  useEffect(() => {
+    const els = headings
+      .map((h) => document.getElementById(h.id))
+      .filter((el): el is HTMLElement => !!el);
+    if (!els.length) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible[0]) setActive(visible[0].target.id);
+      },
+      { rootMargin: "-112px 0px -68% 0px", threshold: 0 }
+    );
+    els.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, [headings]);
+
+  return (
+    <nav aria-label="Table of contents" className="text-sm">
+      <div className="text-xs font-semibold uppercase tracking-[0.2em] text-white/40 mb-4">
+        On this page
+      </div>
+      <ul className="border-l border-white/10">
+        {headings.map((h) => (
+          <li key={h.id}>
+            <a
+              href={`#${h.id}`}
+              onClick={() => setActive(h.id)}
+              className={`block border-l -ml-px pl-4 py-1.5 leading-snug transition-colors ${
+                active === h.id
+                  ? "border-emerald-400 text-white"
+                  : "border-transparent text-white/45 hover:text-white/75"
+              }`}
+            >
+              {h.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}
 
 export function BlogPost() {
   const { slug } = useParams<{
@@ -126,6 +218,26 @@ export function BlogPost() {
       (_, url, id) => `[TWEET_EMBED__${id}](${url})`
     );
   }, [post.content]);
+
+  // Pull a leading hero image out of the body so it renders full-width above
+  // the two-column (table-of-contents + article) layout.
+  const { heroImage, bodyContent } = React.useMemo(() => {
+    const m = contentWithTweets.match(/^\s*!\[([^\]]*)\]\(([^)]+)\)\s*/);
+    if (m) {
+      return {
+        heroImage: { alt: m[1], src: m[2] },
+        bodyContent: contentWithTweets.slice(m[0].length).replace(/^\s+/, ""),
+      };
+    }
+    return { heroImage: null as null | { alt: string; src: string }, bodyContent: contentWithTweets };
+  }, [contentWithTweets]);
+
+  // "Main sections" for the table of contents (H2 headings only).
+  const headings = React.useMemo(
+    () => extractH2Headings(bodyContent),
+    [bodyContent]
+  );
+  const showToc = headings.length >= 2;
 
   let customSchema: Record<string, unknown> | undefined = undefined;
   if (post.id === "ai-recommendation-vs-ai-visibility") {
@@ -665,8 +777,29 @@ export function BlogPost() {
             </div> */}
           </div>
 
+          {/* Hero image (pulled out of the body so the TOC starts below it) */}
+          {heroImage && (
+            <img
+              src={heroImage.src}
+              alt={heroImage.alt}
+              className="w-full rounded-xl border border-white/10 mb-10"
+              loading="eager"
+            />
+          )}
+        </div>
+
+        {/* Table of contents (fixed, left) + article body */}
+        <div className="max-w-5xl mx-auto lg:flex lg:gap-12">
+          {showToc && (
+            <aside className="hidden lg:block w-[210px] flex-shrink-0 order-first">
+              <div className="sticky top-28">
+                <TableOfContents headings={headings} />
+              </div>
+            </aside>
+          )}
+          <div className="min-w-0 flex-1 max-w-3xl">
           {/* Article Content */}
-          <div className="prose prose-invert prose-lg max-w-none mb-16 text-white/80">
+          <div className="prose prose-invert prose-lg max-w-none mb-16 text-zinc-400">
             <ReactMarkdown
               remarkPlugins={[remarkGfm]}
               components={{
@@ -676,11 +809,14 @@ export function BlogPost() {
                     {...props}
                   />
                 ),
-                h2: ({ node, ...props }) => (
+                h2: ({ node, children, ...props }) => (
                   <h2
-                    className="text-3xl font-bold text-white mt-10 mb-5 leading-snug"
+                    id={slugify(nodeToText(children))}
+                    className="text-3xl font-bold text-white mt-10 mb-5 leading-snug scroll-mt-28"
                     {...props}
-                  />
+                  >
+                    {children}
+                  </h2>
                 ),
                 h3: ({ node, ...props }) => (
                   <h3
@@ -704,7 +840,7 @@ export function BlogPost() {
                 ),
                 tbody: ({ node, ...props }) => (
                   <tbody
-                    className="divide-y divide-white/10 text-white/80"
+                    className="divide-y divide-white/10 text-zinc-400"
                     {...props}
                   />
                 ),
@@ -716,13 +852,13 @@ export function BlogPost() {
                 ),
                 ul: ({ node, ...props }) => (
                   <ul
-                    className="list-disc pl-6 mb-6 text-white/80 space-y-2"
+                    className="list-disc pl-6 mb-6 text-zinc-400 space-y-2"
                     {...props}
                   />
                 ),
                 ol: ({ node, ...props }) => (
                   <ol
-                    className="list-decimal pl-6 mb-6 text-white/80 space-y-2"
+                    className="list-decimal pl-6 mb-6 text-zinc-400 space-y-2"
                     {...props}
                   />
                 ),
@@ -737,7 +873,7 @@ export function BlogPost() {
                 ),
                 p: ({ node, ...props }) => (
                   <p
-                    className="mb-3 leading-relaxed text-white/80"
+                    className="mb-3 leading-relaxed text-zinc-400"
                     {...props}
                   />
                 ),
@@ -780,13 +916,13 @@ export function BlogPost() {
                       {...props}
                       target={isExternal ? "_blank" : undefined}
                       rel={isExternal ? "noopener noreferrer" : undefined}
-                      className="underline underline-offset-2 decoration-white/40 hover:decoration-white/80 transition-colors break-words"
+                      className="text-blue-400 underline underline-offset-2 decoration-blue-400/50 hover:text-blue-300 hover:decoration-blue-300 transition-colors break-words"
                     />
                   );
                 }
               }}
             >
-              {contentWithTweets}
+              {bodyContent}
             </ReactMarkdown>
           </div>
 
@@ -865,6 +1001,7 @@ export function BlogPost() {
               </div>
             </div>
           )}
+          </div>
         </div>
       </article>
 


### PR DESCRIPTION
Improves the blog post reading layout (applies to all posts):

- **Table of contents:** a fixed left "On this page" sidebar listing the main sections (H2), with scroll-spy highlighting and smooth in-page navigation. It starts **below the hero image**, matching the requested reference.
- **Hero image:** the leading image is hoisted above the TOC + article two-column layout.
- **Body text:** softened to a muted gray (zinc-400) so it reads comfortably instead of high-contrast white.
- **Links:** in-text links are now blue and underlined.

Verified on the live-built pages: H2 anchor ids + TOC links line up, scroll-spy active state works, and the layout renders as in the reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmfAfNKnLE9VKhFLuaCYdH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmfAfNKnLE9VKhFLuaCYdH)_