### PR TITLE
Blog post: align hero, TOC and body to one shared width

### DIFF
--- a/new-landing/public/rss.xml
+++ b/new-landing/public/rss.xml
@@ -5,7 +5,7 @@
     <link>https://genezio.com/blog/</link>
     <description>The platform built for Generative Search and Answer Engine Optimization.</description>
     <language>en-us</language>
-    <lastBuildDate>Wed, 26 Aug 2026 15:43:16 GMT</lastBuildDate>
+    <lastBuildDate>Wed, 26 Aug 2026 15:56:24 GMT</lastBuildDate>
     <atom:link href="https://genezio.com/rss.xml" rel="self" type="application/rss+xml" />
     
     <item>

--- a/new-landing/src/polymet/pages/blog-post.tsx
+++ b/new-landing/src/polymet/pages/blog-post.tsx
@@ -675,7 +675,7 @@ export function BlogPost() {
       />
       {/* Back Button */}
       <div className="pt-24 pb-8 px-6">
-        <div className="max-w-4xl mx-auto">
+        <div className="max-w-5xl mx-auto">
           <a
             href={`${sectionBasePath}/`}
             className="inline-flex items-center gap-2 text-white/60 hover:text-white transition-colors group"
@@ -689,7 +689,7 @@ export function BlogPost() {
 
       {/* Article Header */}
       <article className="px-6 pb-32">
-        <div className="max-w-4xl mx-auto">
+        <div className="max-w-5xl mx-auto">
           {/* Post Type & Category Badges */}
           <div className="flex flex-wrap items-center gap-3 mb-6">
             {post.postType && (
@@ -786,18 +786,24 @@ export function BlogPost() {
               loading="eager"
             />
           )}
-        </div>
 
-        {/* Table of contents (fixed, left) + article body */}
-        <div className="max-w-5xl mx-auto lg:flex lg:gap-12">
-          {showToc && (
-            <aside className="hidden lg:block w-[210px] flex-shrink-0 order-first">
-              <div className="sticky top-28">
-                <TableOfContents headings={headings} />
-              </div>
-            </aside>
-          )}
-          <div className="min-w-0 flex-1 max-w-3xl">
+          {/* Table of contents (fixed, left) + article body — one grid so the
+              hero, header and TOC all share the same left edge */}
+          <div
+            className={
+              showToc
+                ? "lg:grid lg:grid-cols-[210px_minmax(0,1fr)] lg:gap-12"
+                : ""
+            }
+          >
+            {showToc && (
+              <aside className="hidden lg:block">
+                <div className="sticky top-28">
+                  <TableOfContents headings={headings} />
+                </div>
+              </aside>
+            )}
+            <div className={showToc ? "min-w-0" : "min-w-0 max-w-3xl mx-auto"}>
           {/* Article Content */}
           <div className="prose prose-invert prose-lg max-w-none mb-16 text-zinc-400">
             <ReactMarkdown
@@ -1001,6 +1007,7 @@ export function BlogPost() {
               </div>
             </div>
           )}
+            </div>
           </div>
         </div>
       </article>


### PR DESCRIPTION
The header, hero image and body column were at different widths / left edges. Now they all live in a single `max-w-5xl` container: the header and full-width hero span the top, and below them a `[TOC | body]` grid keeps the TOC in the left column aligned with the hero's left edge while the body fills the right column — matching the reference layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmfAfNKnLE9VKhFLuaCYdH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmfAfNKnLE9VKhFLuaCYdH)_