### PR TITLE
Blog article: align header and footer to the narrower reading width

### DIFF
--- a/new-landing/public/rss.xml
+++ b/new-landing/public/rss.xml
@@ -5,7 +5,7 @@
     <link>https://genezio.com/blog/</link>
     <description>The platform built for Generative Search and Answer Engine Optimization.</description>
     <language>en-us</language>
-    <lastBuildDate>Wed, 26 Aug 2026 15:56:24 GMT</lastBuildDate>
+    <lastBuildDate>Wed, 26 Aug 2026 16:02:21 GMT</lastBuildDate>
     <atom:link href="https://genezio.com/rss.xml" rel="self" type="application/rss+xml" />
     
     <item>

--- a/new-landing/src/polymet/components/genezio-footer.tsx
+++ b/new-landing/src/polymet/components/genezio-footer.tsx
@@ -45,10 +45,14 @@ const COLUMNS: { heading: string; links: { label: string; href: string }[] }[] =
   },
 ];
 
-export function GenezioFooter() {
+export function GenezioFooter({
+  maxWidthClass = "max-w-7xl",
+}: {
+  maxWidthClass?: string;
+} = {}) {
   return (
     <footer className="bg-[#050506] border-t border-white/10">
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 py-12 md:py-16">
+      <div className={`${maxWidthClass} mx-auto px-6 md:px-8 lg:px-16 py-12 md:py-16`}>
         <div className="grid grid-cols-2 lg:grid-cols-6 gap-8 md:gap-10 mb-10">
           {/* Brand */}
           <div className="col-span-2">

--- a/new-landing/src/polymet/components/genezio-header.tsx
+++ b/new-landing/src/polymet/components/genezio-header.tsx
@@ -19,7 +19,11 @@ import { useState, useRef, useEffect } from "react";
 import { Link } from "react-router";
 
 
-export function GenezioHeader() {
+export function GenezioHeader({
+  maxWidthClass = "max-w-7xl",
+}: {
+  maxWidthClass?: string;
+} = {}) {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [platformMenuOpen, setPlatformMenuOpen] = useState(false);
   const [resourcesMenuOpen, setResourcesMenuOpen] = useState(false);
@@ -78,7 +82,7 @@ export function GenezioHeader() {
 
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-black/80 backdrop-blur-md border-b border-white/5">
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 py-4 flex items-center justify-between">
+      <div className={`${maxWidthClass} mx-auto px-6 md:px-8 lg:px-16 py-4 flex items-center justify-between`}>
         {/* Logo */}
         <a href="/" className="flex items-center gap-2 group" aria-label="Genezio Homepage">
           <span className="text-white text-xl font-semibold">

--- a/new-landing/src/polymet/layouts/genezio-layout.tsx
+++ b/new-landing/src/polymet/layouts/genezio-layout.tsx
@@ -14,12 +14,19 @@ export function GenezioLayout({ children }: GenezioLayoutProps) {
     // Scroll to top or handle path changes if needed, but SEO is now handled by PolymetSEO per-page.
   }, [location.pathname]);
 
+  // Blog/research article pages use a narrower reading container; align the
+  // header and footer to the same width so all three share the same edges.
+  const isArticle =
+    /^\/(blog|research)\/[^/]+\/?$/.test(location.pathname) &&
+    !location.pathname.startsWith("/blog/author");
+  const containerWidth = isArticle ? "max-w-5xl" : "max-w-7xl";
+
   return (
     <div className="min-h-screen bg-[#050506] text-foreground flex flex-col">
-      <GenezioHeader />
+      <GenezioHeader maxWidthClass={containerWidth} />
 
       <main className="flex-1">{children}</main>
-      <GenezioFooter />
+      <GenezioFooter maxWidthClass={containerWidth} />
     </div>
   );
 }

--- a/new-landing/src/polymet/pages/blog-post.tsx
+++ b/new-landing/src/polymet/pages/blog-post.tsx
@@ -674,8 +674,8 @@ export function BlogPost() {
         tags={post.tags}
       />
       {/* Back Button */}
-      <div className="pt-24 pb-8 px-6">
-        <div className="max-w-5xl mx-auto">
+      <div className="pt-24 pb-8">
+        <div className="max-w-5xl mx-auto px-6 md:px-8 lg:px-16">
           <a
             href={`${sectionBasePath}/`}
             className="inline-flex items-center gap-2 text-white/60 hover:text-white transition-colors group"
@@ -688,8 +688,8 @@ export function BlogPost() {
       </div>
 
       {/* Article Header */}
-      <article className="px-6 pb-32">
-        <div className="max-w-5xl mx-auto">
+      <article className="pb-32">
+        <div className="max-w-5xl mx-auto px-6 md:px-8 lg:px-16">
           {/* Post Type & Category Badges */}
           <div className="flex flex-wrap items-center gap-3 mb-6">
             {post.postType && (
@@ -1013,8 +1013,8 @@ export function BlogPost() {
       </article>
 
       {/* CTA Section */}
-      <section className="px-6 pb-32">
-        <div className="max-w-4xl mx-auto">
+      <section className="pb-32">
+        <div className="max-w-5xl mx-auto px-6 md:px-8 lg:px-16">
           <div className="relative bg-white/5 border border-white/10 rounded-2xl p-12 overflow-hidden">
             {/* Background gradient */}
             <div className="absolute inset-0 bg-gradient-to-br from-zinc-600/10 via-white/10 to-transparent" />


### PR DESCRIPTION
On blog/research **article** pages, the global header and footer now render at the same `max-w-5xl` width as the article, so the nav, content, and footer all share the same left/right edges (instead of nav/footer being wider at `max-w-7xl`).

- `GenezioHeader` / `GenezioFooter` take an optional `maxWidthClass` prop (default `max-w-7xl`).
- `GenezioLayout` detects article routes and passes `max-w-5xl` to both.
- The article, back-button, and CTA use the identical container classes for pixel-aligned edges.
- All other pages (homepage, pricing, listings, etc.) are unchanged at `max-w-7xl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmfAfNKnLE9VKhFLuaCYdH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmfAfNKnLE9VKhFLuaCYdH)_