### PR TITLE
Blog article: align content width with header/footer (max-w-7xl)

### DIFF
--- a/new-landing/public/rss.xml
+++ b/new-landing/public/rss.xml
@@ -5,7 +5,7 @@
     <link>https://genezio.com/blog/</link>
     <description>The platform built for Generative Search and Answer Engine Optimization.</description>
     <language>en-us</language>
-    <lastBuildDate>Wed, 26 Aug 2026 16:02:21 GMT</lastBuildDate>
+    <lastBuildDate>Wed, 26 Aug 2026 16:15:53 GMT</lastBuildDate>
     <atom:link href="https://genezio.com/rss.xml" rel="self" type="application/rss+xml" />
     
     <item>

--- a/new-landing/src/polymet/components/genezio-footer.tsx
+++ b/new-landing/src/polymet/components/genezio-footer.tsx
@@ -45,14 +45,10 @@ const COLUMNS: { heading: string; links: { label: string; href: string }[] }[] =
   },
 ];
 
-export function GenezioFooter({
-  maxWidthClass = "max-w-7xl",
-}: {
-  maxWidthClass?: string;
-} = {}) {
+export function GenezioFooter() {
   return (
     <footer className="bg-[#050506] border-t border-white/10">
-      <div className={`${maxWidthClass} mx-auto px-6 md:px-8 lg:px-16 py-12 md:py-16`}>
+      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 py-12 md:py-16">
         <div className="grid grid-cols-2 lg:grid-cols-6 gap-8 md:gap-10 mb-10">
           {/* Brand */}
           <div className="col-span-2">

--- a/new-landing/src/polymet/components/genezio-header.tsx
+++ b/new-landing/src/polymet/components/genezio-header.tsx
@@ -19,11 +19,7 @@ import { useState, useRef, useEffect } from "react";
 import { Link } from "react-router";
 
 
-export function GenezioHeader({
-  maxWidthClass = "max-w-7xl",
-}: {
-  maxWidthClass?: string;
-} = {}) {
+export function GenezioHeader() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [platformMenuOpen, setPlatformMenuOpen] = useState(false);
   const [resourcesMenuOpen, setResourcesMenuOpen] = useState(false);
@@ -82,7 +78,7 @@ export function GenezioHeader({
 
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-black/80 backdrop-blur-md border-b border-white/5">
-      <div className={`${maxWidthClass} mx-auto px-6 md:px-8 lg:px-16 py-4 flex items-center justify-between`}>
+      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 py-4 flex items-center justify-between">
         {/* Logo */}
         <a href="/" className="flex items-center gap-2 group" aria-label="Genezio Homepage">
           <span className="text-white text-xl font-semibold">

--- a/new-landing/src/polymet/layouts/genezio-layout.tsx
+++ b/new-landing/src/polymet/layouts/genezio-layout.tsx
@@ -14,19 +14,12 @@ export function GenezioLayout({ children }: GenezioLayoutProps) {
     // Scroll to top or handle path changes if needed, but SEO is now handled by PolymetSEO per-page.
   }, [location.pathname]);
 
-  // Blog/research article pages use a narrower reading container; align the
-  // header and footer to the same width so all three share the same edges.
-  const isArticle =
-    /^\/(blog|research)\/[^/]+\/?$/.test(location.pathname) &&
-    !location.pathname.startsWith("/blog/author");
-  const containerWidth = isArticle ? "max-w-5xl" : "max-w-7xl";
-
   return (
     <div className="min-h-screen bg-[#050506] text-foreground flex flex-col">
-      <GenezioHeader maxWidthClass={containerWidth} />
+      <GenezioHeader />
 
       <main className="flex-1">{children}</main>
-      <GenezioFooter maxWidthClass={containerWidth} />
+      <GenezioFooter />
     </div>
   );
 }

--- a/new-landing/src/polymet/pages/blog-post.tsx
+++ b/new-landing/src/polymet/pages/blog-post.tsx
@@ -675,7 +675,7 @@ export function BlogPost() {
       />
       {/* Back Button */}
       <div className="pt-24 pb-8">
-        <div className="max-w-5xl mx-auto px-6 md:px-8 lg:px-16">
+        <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
           <a
             href={`${sectionBasePath}/`}
             className="inline-flex items-center gap-2 text-white/60 hover:text-white transition-colors group"
@@ -689,7 +689,7 @@ export function BlogPost() {
 
       {/* Article Header */}
       <article className="pb-32">
-        <div className="max-w-5xl mx-auto px-6 md:px-8 lg:px-16">
+        <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
           {/* Post Type & Category Badges */}
           <div className="flex flex-wrap items-center gap-3 mb-6">
             {post.postType && (
@@ -1014,7 +1014,7 @@ export function BlogPost() {
 
       {/* CTA Section */}
       <section className="pb-32">
-        <div className="max-w-5xl mx-auto px-6 md:px-8 lg:px-16">
+        <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
           <div className="relative bg-white/5 border border-white/10 rounded-2xl p-12 overflow-hidden">
             {/* Background gradient */}
             <div className="absolute inset-0 bg-gradient-to-br from-zinc-600/10 via-white/10 to-transparent" />


### PR DESCRIPTION
Reverts the previous blog-scoped header/footer narrowing — header and footer keep their standard `max-w-7xl` width on all pages (same as the homepage). Instead, the blog article container (back button, article, CTA) is widened to the same `max-w-7xl` with matching padding, so the article content aligns with the nav and footer edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmfAfNKnLE9VKhFLuaCYdH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmfAfNKnLE9VKhFLuaCYdH)_