### PR TITLE
Unify site content width to max-w-6xl everywhere

### DIFF
--- a/new-landing/public/rss.xml
+++ b/new-landing/public/rss.xml
@@ -5,7 +5,7 @@
     <link>https://genezio.com/blog/</link>
     <description>The platform built for Generative Search and Answer Engine Optimization.</description>
     <language>en-us</language>
-    <lastBuildDate>Wed, 26 Aug 2026 16:15:53 GMT</lastBuildDate>
+    <lastBuildDate>Wed, 26 Aug 2026 18:53:09 GMT</lastBuildDate>
     <atom:link href="https://genezio.com/rss.xml" rel="self" type="application/rss+xml" />
     
     <item>

--- a/new-landing/src/polymet/components/about-achievements-section.tsx
+++ b/new-landing/src/polymet/components/about-achievements-section.tsx
@@ -49,7 +49,7 @@ export function AboutAchievementsSection() {
 
       {/* Subtle glow */}
 
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
         {/* Section header */}
         <div className="text-center mb-12 md:mb-16">
           <HeroEyebrow className="mb-6 mx-auto w-fit">Milestones</HeroEyebrow>

--- a/new-landing/src/polymet/components/about-approach-section.tsx
+++ b/new-landing/src/polymet/components/about-approach-section.tsx
@@ -33,7 +33,7 @@ export function AboutApproachSection() {
 
       {/* Subtle glow */}
 
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
         {/* Section header */}
         <div className="text-center mb-12 md:mb-16">
           <HeroEyebrow className="mb-6 mx-auto w-fit">How we work</HeroEyebrow>

--- a/new-landing/src/polymet/components/about-community-section.tsx
+++ b/new-landing/src/polymet/components/about-community-section.tsx
@@ -10,7 +10,7 @@ export function AboutCommunitySection() {
         {/* Top hairline divider */}
         <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
 
-        <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
+        <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
           <div className="text-center mb-12">
             <HeroEyebrow className="mb-6 mx-auto w-fit">Community</HeroEyebrow>
             <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-6 leading-tight">

--- a/new-landing/src/polymet/components/about-customers-section.tsx
+++ b/new-landing/src/polymet/components/about-customers-section.tsx
@@ -38,7 +38,7 @@ export function AboutCustomersSection() {
 
       {/* Subtle glow */}
 
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
         <div className="grid lg:grid-cols-2 gap-12 lg:gap-16 items-center">
           {/* Left: Text content */}
           <div>

--- a/new-landing/src/polymet/components/about-hero-section.tsx
+++ b/new-landing/src/polymet/components/about-hero-section.tsx
@@ -11,7 +11,7 @@ export function AboutHeroSection() {
     <section className="relative bg-[#050506] pt-40 pb-20 overflow-hidden">
       {/* Subtle center glow */}
 
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
         <div className="max-w-4xl mx-auto text-center">
           {/* Eyebrow */}
           <HeroEyebrow className="mb-8 mx-auto w-fit">

--- a/new-landing/src/polymet/components/about-story-section.tsx
+++ b/new-landing/src/polymet/components/about-story-section.tsx
@@ -48,7 +48,7 @@ export function AboutStorySection() {
 
       {/* Subtle glow */}
 
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
         {/* Section header */}
         <div className="text-center mb-12 md:mb-16">
           <HeroEyebrow className="mb-6 mx-auto w-fit">Our story</HeroEyebrow>

--- a/new-landing/src/polymet/components/about-team-section.tsx
+++ b/new-landing/src/polymet/components/about-team-section.tsx
@@ -41,7 +41,7 @@ export function AboutTeamSection() {
 
       {/* Subtle glow */}
 
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
         {/* Section header */}
         <div className="text-center mb-12 md:mb-16">
           <HeroEyebrow className="mb-6 mx-auto w-fit">The team</HeroEyebrow>

--- a/new-landing/src/polymet/components/about-values-section.tsx
+++ b/new-landing/src/polymet/components/about-values-section.tsx
@@ -41,7 +41,7 @@ export function AboutValuesSection() {
 
       {/* Subtle glow */}
 
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
         {/* Section header */}
         <div className="text-center mb-12 md:mb-16">
           <HeroEyebrow className="mb-6 mx-auto w-fit">Our values</HeroEyebrow>

--- a/new-landing/src/polymet/components/about-what-we-do-section.tsx
+++ b/new-landing/src/polymet/components/about-what-we-do-section.tsx
@@ -55,7 +55,7 @@ export function AboutWhatWeDoSection() {
 
       {/* Subtle glow */}
 
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
         {/* Section header */}
         <div className="text-center mb-12 md:mb-16">
           <HeroEyebrow className="mb-6 mx-auto w-fit">What we do</HeroEyebrow>

--- a/new-landing/src/polymet/components/agency-brand-scan-section.tsx
+++ b/new-landing/src/polymet/components/agency-brand-scan-section.tsx
@@ -23,7 +23,7 @@ export function AgencyBrandScanSection() {
     <section className="relative py-24 md:py-32 bg-[#0E0E10] px-6 md:px-8 lg:px-16">
       {/* Top hairline divider */}
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
-      <div className="max-w-7xl mx-auto">
+      <div className="max-w-6xl mx-auto">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
           {/* Left side - Content */}
           <div>

--- a/new-landing/src/polymet/components/agency-content-strategy-section.tsx
+++ b/new-landing/src/polymet/components/agency-content-strategy-section.tsx
@@ -6,7 +6,7 @@ export function AgencyContentStrategySection() {
     <section className="relative py-24 md:py-32 bg-[#0E0E10] px-6 md:px-8 lg:px-16">
       {/* Top hairline divider */}
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
-      <div className="max-w-7xl mx-auto">
+      <div className="max-w-6xl mx-auto">
         {/* Section header */}
         <div className="text-center mb-8 md:mb-16">
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-4 leading-tight">

--- a/new-landing/src/polymet/components/agency-geo-section.tsx
+++ b/new-landing/src/polymet/components/agency-geo-section.tsx
@@ -5,7 +5,7 @@ export function AgencyGeoSection() {
     <section className="relative py-24 md:py-32 bg-[#050506] px-6 md:px-8 lg:px-16">
       {/* Top hairline divider */}
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
-      <div className="max-w-7xl mx-auto">
+      <div className="max-w-6xl mx-auto">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 md:gap-16 items-center">
           {/* Left content */}
           <div>

--- a/new-landing/src/polymet/components/agency-hero-section.tsx
+++ b/new-landing/src/polymet/components/agency-hero-section.tsx
@@ -48,7 +48,7 @@ export function AgencyHeroSection() {
             </Link>
           </div>
 
-          <div className="hidden md:block max-w-7xl mx-auto mt-8 sm:mt-12 md:mt-16 lg:mt-24 overflow-hidden">
+          <div className="hidden md:block max-w-6xl mx-auto mt-8 sm:mt-12 md:mt-16 lg:mt-24 overflow-hidden">
             <AgencyBrandMarquee />
           </div>
         </div>

--- a/new-landing/src/polymet/components/agency-monitoring-section.tsx
+++ b/new-landing/src/polymet/components/agency-monitoring-section.tsx
@@ -130,7 +130,7 @@ export function AgencyMonitoringSection() {
     <section className="relative py-24 md:py-32 bg-[#0E0E10] px-6 md:px-8 lg:px-16">
       {/* Top hairline divider */}
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
-      <div className="max-w-7xl mx-auto">
+      <div className="max-w-6xl mx-auto">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 md:gap-16 items-center">
           {/* Right content */}
           <div className="order-1 lg:order-1">

--- a/new-landing/src/polymet/components/agency-scale-section.tsx
+++ b/new-landing/src/polymet/components/agency-scale-section.tsx
@@ -155,7 +155,7 @@ import {
       <section className="relative py-24 md:py-32 bg-[#050506] px-6 md:px-8 lg:px-16">
         {/* Top hairline divider */}
         <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
-        <div className="max-w-7xl mx-auto">
+        <div className="max-w-6xl mx-auto">
           {/* Section header */}
           <div className="text-center mb-8 md:mb-16">
             <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-4 leading-tight">

--- a/new-landing/src/polymet/components/agency-testimonials-section.tsx
+++ b/new-landing/src/polymet/components/agency-testimonials-section.tsx
@@ -16,7 +16,7 @@ export function AgencyTestimonialsSection() {
     <section className="relative py-24 md:py-32 bg-[#050506] px-6 md:px-8 lg:px-16">
       {/* Top hairline divider */}
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
-      <div className="max-w-7xl mx-auto">
+      <div className="max-w-6xl mx-auto">
         {/* Section Header */}
         <div className="text-center mb-8 md:mb-16">
           <HeroEyebrow className="mb-6 mx-auto w-fit">Loved by agencies</HeroEyebrow>

--- a/new-landing/src/polymet/components/agent-scoring-cards.tsx
+++ b/new-landing/src/polymet/components/agent-scoring-cards.tsx
@@ -119,7 +119,7 @@ export function AgentScoringCards() {
       {/* Background Elements */}
       <div className="absolute inset-0 bg-gradient-to-b from-white/[0.04] via-transparent to-transparent" />
 
-      <div className="relative max-w-7xl mx-auto px-6 sm:px-8 lg:px-16">
+      <div className="relative max-w-6xl mx-auto px-6 sm:px-8 lg:px-16">
         {/* Section Header */}
         <div className="text-center mb-12 sm:mb-16">
           <HeroEyebrow className="mb-6">Agent Performance</HeroEyebrow>

--- a/new-landing/src/polymet/components/bt-testimonial-section.tsx
+++ b/new-landing/src/polymet/components/bt-testimonial-section.tsx
@@ -4,7 +4,7 @@ import btLogo from "../../assets/bt.svg";
 export function BtTestimonialSection() {
     return (
         <section className="relative py-20 md:py-32 bg-[#050506]">
-            <div className="container mx-auto px-6 max-w-7xl">
+            <div className="container mx-auto px-6 max-w-6xl">
                 {/* Main Testimonial Card */}
                 <div className="relative bg-gradient-to-br from-[#0E0E10] to-[#1A1A1F] border border-white/5 rounded-3xl overflow-hidden">
                     {/* Gradient Overlay */}

--- a/new-landing/src/polymet/components/conversation-analysis.tsx
+++ b/new-landing/src/polymet/components/conversation-analysis.tsx
@@ -109,7 +109,7 @@ export function ConversationAnalysis() {
       {/* Background Elements */}
       <div className="absolute inset-0 bg-gradient-to-b from-zinc-500/5 via-transparent to-zinc-500/5" />
 
-      <div className="relative max-w-7xl mx-auto px-6 sm:px-8 lg:px-16">
+      <div className="relative max-w-6xl mx-auto px-6 sm:px-8 lg:px-16">
         {/* Section Header */}
         <div className="text-center mb-12 sm:mb-16">
           <HeroEyebrow className="mb-6">Conversation Classification</HeroEyebrow>

--- a/new-landing/src/polymet/components/conversation-classification.tsx
+++ b/new-landing/src/polymet/components/conversation-classification.tsx
@@ -89,7 +89,7 @@ export function ConversationClassification() {
       {/* Background Elements */}
       <div className="absolute inset-0 bg-gradient-to-b from-zinc-500/5 via-transparent to-zinc-500/5" />
 
-      <div className="relative max-w-7xl mx-auto px-6 sm:px-8 lg:px-16">
+      <div className="relative max-w-6xl mx-auto px-6 sm:px-8 lg:px-16">
         {/* Section Header */}
         <div className="text-center mb-12 sm:mb-16">
           <HeroEyebrow className="mb-6">Smart Classification</HeroEyebrow>

--- a/new-landing/src/polymet/components/conversion-hero.tsx
+++ b/new-landing/src/polymet/components/conversion-hero.tsx
@@ -19,7 +19,7 @@ export function ConversionHero() {
       {/* Grid Pattern */}
       <div className="absolute inset-0 bg-[linear-gradient(to_right,#ffffff05_1px,transparent_1px),linear-gradient(to_bottom,#ffffff05_1px,transparent_1px)] bg-[size:4rem_4rem]" />
 
-      <div className="relative max-w-7xl mx-auto px-6 sm:px-8 lg:px-16 py-12 sm:py-20 w-full">
+      <div className="relative max-w-6xl mx-auto px-6 sm:px-8 lg:px-16 py-12 sm:py-20 w-full">
         <div className="grid lg:grid-cols-2 gap-8 lg:gap-12 items-center">
           {/* Left Content */}
           <div className="space-y-6 sm:space-y-8">

--- a/new-landing/src/polymet/components/conversion-process.tsx
+++ b/new-landing/src/polymet/components/conversion-process.tsx
@@ -9,7 +9,7 @@ export function ConversionProcess() {
 
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,_var(--tw-gradient-stops))] from-zinc-500/10 via-transparent to-transparent" />
 
-      <div className="relative max-w-7xl mx-auto px-6 sm:px-8 lg:px-16">
+      <div className="relative max-w-6xl mx-auto px-6 sm:px-8 lg:px-16">
         {/* Section Header */}
         <div className="text-center mb-16">
           <HeroEyebrow className="mb-6">How It Works</HeroEyebrow>

--- a/new-landing/src/polymet/components/conversion-testimonials.tsx
+++ b/new-landing/src/polymet/components/conversion-testimonials.tsx
@@ -29,7 +29,7 @@ export function ConversionTestimonials() {
       {/* Background gradient - Banner style */}
       <div className="absolute inset-0 bg-white/5" />
 
-      <div className="relative max-w-7xl mx-auto px-6 sm:px-8 lg:px-16">
+      <div className="relative max-w-6xl mx-auto px-6 sm:px-8 lg:px-16">
         {/* Testimonials Banner - Full Width Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           {testimonials.map((testimonial, index) => (

--- a/new-landing/src/polymet/components/cross-analysis.tsx
+++ b/new-landing/src/polymet/components/cross-analysis.tsx
@@ -74,7 +74,7 @@ export function CrossAnalysis() {
 
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,_var(--tw-gradient-stops))] from-zinc-500/10 via-transparent to-transparent" />
 
-      <div className="relative max-w-7xl mx-auto px-6 sm:px-8 lg:px-16">
+      <div className="relative max-w-6xl mx-auto px-6 sm:px-8 lg:px-16">
         {/* Section Header */}
         <div className="text-center mb-12 sm:mb-16">
           <HeroEyebrow className="mb-6">Cross-Analysis</HeroEyebrow>

--- a/new-landing/src/polymet/components/csat-hero.tsx
+++ b/new-landing/src/polymet/components/csat-hero.tsx
@@ -16,7 +16,7 @@ export function CsatHero() {
 
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,_var(--tw-gradient-stops))] from-white/[0.04] via-transparent to-transparent" />
 
-      <div className="relative max-w-7xl mx-auto px-6 sm:px-8 lg:px-16 py-12 sm:py-20 w-full">
+      <div className="relative max-w-6xl mx-auto px-6 sm:px-8 lg:px-16 py-12 sm:py-20 w-full">
         <div className="grid lg:grid-cols-2 gap-8 lg:gap-12 items-center">
           {/* Left: Copy */}
           <div className="space-y-6 sm:space-y-8">

--- a/new-landing/src/polymet/components/escalation-reduction.tsx
+++ b/new-landing/src/polymet/components/escalation-reduction.tsx
@@ -92,7 +92,7 @@ export function EscalationReduction() {
 
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,_var(--tw-gradient-stops))] from-white/[0.04] via-transparent to-transparent" />
 
-      <div className="relative max-w-7xl mx-auto px-6 sm:px-8 lg:px-16">
+      <div className="relative max-w-6xl mx-auto px-6 sm:px-8 lg:px-16">
         {/* Section Header */}
         <div className="text-center mb-12 sm:mb-16">
           <HeroEyebrow className="mb-6">Escalation Management</HeroEyebrow>

--- a/new-landing/src/polymet/components/genezio-ai-traffic-section.tsx
+++ b/new-landing/src/polymet/components/genezio-ai-traffic-section.tsx
@@ -51,7 +51,7 @@ export function GenezioAiTrafficSection() {
     <section className="relative py-24 md:py-32 bg-[#0E0E10] overflow-hidden">
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
 
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
         {/* Header */}
         <div className="max-w-3xl mx-auto text-center mb-14 md:mb-20">
           <HeroEyebrow className="mb-6 mx-auto w-fit">

--- a/new-landing/src/polymet/components/genezio-brand-plans.tsx
+++ b/new-landing/src/polymet/components/genezio-brand-plans.tsx
@@ -36,7 +36,7 @@ export function GenezioBrandPlans() {
 
   return (
     <section className="py-20 px-6 bg-[#0E0E10]">
-      <div className="max-w-7xl mx-auto">
+      <div className="max-w-6xl mx-auto">
         {/* Section Header */}
         <div className="text-center mb-16">
           <h2 className="text-4xl md:text-5xl font-bold text-white mb-4">Plans for Brands</h2>

--- a/new-landing/src/polymet/components/genezio-branded-questions-section.tsx
+++ b/new-landing/src/polymet/components/genezio-branded-questions-section.tsx
@@ -73,7 +73,7 @@ export function GenezioBrandedQuestionsSection() {
       {/* Decorative gradient line */}
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
 
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         {/* Header */}
         <div className="text-center mb-12 md:mb-20">
           <HeroEyebrow className="mb-4 mx-auto w-fit">Direct AI Perception Analysis</HeroEyebrow>

--- a/new-landing/src/polymet/components/genezio-dashboard-section.tsx
+++ b/new-landing/src/polymet/components/genezio-dashboard-section.tsx
@@ -118,7 +118,7 @@ export function GenezioDashboardSection() {
       {/* Background decoration */}
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(16, 185, 129,0.08),transparent_70%)]" />
 
-      <div className="max-w-7xl mx-auto px-6 relative z-10">
+      <div className="max-w-6xl mx-auto px-6 relative z-10">
         {/* Header */}
         <div className="text-center mb-16">
           <h2 className="text-4xl md:text-5xl font-bold text-white mb-6 leading-tight">

--- a/new-landing/src/polymet/components/genezio-differentiators-section.tsx
+++ b/new-landing/src/polymet/components/genezio-differentiators-section.tsx
@@ -143,7 +143,7 @@ export function GenezioDifferentiatorsSection() {
       {/* Decorative gradient line */}
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
 
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         {/* Header */}
         <div className="text-center mb-12 md:mb-20">
           <HeroEyebrow className="mb-4 mx-auto w-fit">Drive measurable business outcomes</HeroEyebrow>

--- a/new-landing/src/polymet/components/genezio-enterprise-section.tsx
+++ b/new-landing/src/polymet/components/genezio-enterprise-section.tsx
@@ -31,7 +31,7 @@ export function GenezioEnterpriseSection() {
   return (
     <section className="relative py-24 md:py-32 bg-[#050506]">
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         <div className="max-w-3xl mb-12 md:mb-16">
           <HeroEyebrow className="mb-6">Built for enterprise</HeroEyebrow>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-6 leading-tight">

--- a/new-landing/src/polymet/components/genezio-enterprise-trust-band.tsx
+++ b/new-landing/src/polymet/components/genezio-enterprise-trust-band.tsx
@@ -20,7 +20,7 @@ export function GenezioEnterpriseTrustBand() {
 
   return (
     <section className="py-12 md:py-16 bg-[#050506] relative">
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         <p className="text-center text-xs md:text-sm text-white/60 uppercase tracking-[0.2em] font-medium mb-8">
           Built for the enterprise
         </p>

--- a/new-landing/src/polymet/components/genezio-expert-services.tsx
+++ b/new-landing/src/polymet/components/genezio-expert-services.tsx
@@ -40,7 +40,7 @@ export function GenezioExpertServices() {
     <section className="relative py-24 md:py-32 bg-[#0E0E10]">
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
 
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         <div className="text-center max-w-3xl mx-auto mb-12 md:mb-16">
           <HeroEyebrow className="mb-6 mx-auto w-fit">
             Dedicated expert services

--- a/new-landing/src/polymet/components/genezio-flywheel-section.tsx
+++ b/new-landing/src/polymet/components/genezio-flywheel-section.tsx
@@ -43,7 +43,7 @@ export function GenezioBusinessGoalsSection() {
     <section className="relative py-24 md:py-32 bg-[#050506] overflow-hidden">
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
 
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
         <div className="mb-12 md:mb-16 max-w-3xl">
           <HeroEyebrow className="mb-6">Business goals</HeroEyebrow>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white leading-tight">

--- a/new-landing/src/polymet/components/genezio-footer.tsx
+++ b/new-landing/src/polymet/components/genezio-footer.tsx
@@ -48,7 +48,7 @@ const COLUMNS: { heading: string; links: { label: string; href: string }[] }[] =
 export function GenezioFooter() {
   return (
     <footer className="bg-[#050506] border-t border-white/10">
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 py-12 md:py-16">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16 py-12 md:py-16">
         <div className="grid grid-cols-2 lg:grid-cols-6 gap-8 md:gap-10 mb-10">
           {/* Brand */}
           <div className="col-span-2">

--- a/new-landing/src/polymet/components/genezio-header.tsx
+++ b/new-landing/src/polymet/components/genezio-header.tsx
@@ -78,7 +78,7 @@ export function GenezioHeader() {
 
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-black/80 backdrop-blur-md border-b border-white/5">
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 py-4 flex items-center justify-between">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16 py-4 flex items-center justify-between">
         {/* Logo */}
         <a href="/" className="flex items-center gap-2 group" aria-label="Genezio Homepage">
           <span className="text-white text-xl font-semibold">

--- a/new-landing/src/polymet/components/genezio-hero-section.tsx
+++ b/new-landing/src/polymet/components/genezio-hero-section.tsx
@@ -16,7 +16,7 @@ export function GenezioHeroSection() {
     <section className="relative overflow-hidden bg-[#050506] pt-32 pb-20 md:pt-44 md:pb-28">
       {/* Single, restrained glow */}
 
-      <div className="relative z-10 max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="relative z-10 max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         <div className="grid grid-cols-1 lg:grid-cols-[1.05fr_0.95fr] gap-14 lg:gap-20 items-center">
           {/* Left: headline */}
           <div className="text-center lg:text-left">

--- a/new-landing/src/polymet/components/genezio-insights-section.tsx
+++ b/new-landing/src/polymet/components/genezio-insights-section.tsx
@@ -36,7 +36,7 @@ export function GenezioInsightsSection() {
 
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_70%_50%,rgba(77,195,255,0.05),transparent_50%)]" />
 
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
         {/* Header */}
         <div className="text-center mb-12 md:mb-20">
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-6 leading-tight">

--- a/new-landing/src/polymet/components/genezio-official-section.tsx
+++ b/new-landing/src/polymet/components/genezio-official-section.tsx
@@ -33,7 +33,7 @@ export function GenezioOfficialSection() {
 
   return (
     <section className="relative py-24 md:py-32 bg-[#050506] overflow-hidden">
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
         <div className="text-center mb-14 md:mb-16">
           <HeroEyebrow className="mb-6">It's official</HeroEyebrow>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white leading-tight max-w-4xl mx-auto">

--- a/new-landing/src/polymet/components/genezio-perception-section.tsx
+++ b/new-landing/src/polymet/components/genezio-perception-section.tsx
@@ -158,7 +158,7 @@ export function GenezioPerceptionSection() {
     <section className="relative py-24 md:py-32 bg-[#050506] overflow-hidden">
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
 
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-center">
           {/* Left: the questions you must answer today */}
           <div>

--- a/new-landing/src/polymet/components/genezio-playbook-section.tsx
+++ b/new-landing/src/polymet/components/genezio-playbook-section.tsx
@@ -34,7 +34,7 @@ export function GenezioPlaybookSection() {
     <section className="relative py-24 md:py-32 bg-[#0E0E10] overflow-hidden">
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
 
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
         <div className="text-center mb-12 md:mb-16">
           <HeroEyebrow className="mb-4 mx-auto w-fit">The playbook</HeroEyebrow>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white leading-tight max-w-3xl mx-auto">

--- a/new-landing/src/polymet/components/genezio-pricing-comparison.tsx
+++ b/new-landing/src/polymet/components/genezio-pricing-comparison.tsx
@@ -146,7 +146,7 @@ export function GenezioPricingComparison() {
 
   return (
     <section className="relative py-16 md:py-24 px-6 md:px-8 lg:px-16 bg-[#050506]">
-      <div className="relative max-w-7xl mx-auto">
+      <div className="relative max-w-6xl mx-auto">
         {/* Header */}
         <div className="text-center mb-12 md:mb-16">
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-4">

--- a/new-landing/src/polymet/components/genezio-problem-section.tsx
+++ b/new-landing/src/polymet/components/genezio-problem-section.tsx
@@ -11,7 +11,7 @@ export function GenezioProblemsSection() {
       {/* Subtle gradient accent */}
       <div className="absolute top-0 left-1/2 -translate-x-1/2 w-full max-w-4xl h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
 
-      <div className="max-w-7xl mx-auto px-6">
+      <div className="max-w-6xl mx-auto px-6">
         <div className="grid lg:grid-cols-2 gap-16 items-center">
           {/* Left: Text content */}
           <div>

--- a/new-landing/src/polymet/components/genezio-product-pillars-section.tsx
+++ b/new-landing/src/polymet/components/genezio-product-pillars-section.tsx
@@ -56,7 +56,7 @@ export function GenezioProductPillarsSection() {
     <section className="relative py-24 md:py-32 bg-[#0E0E10] overflow-hidden">
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
 
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
         <div className="text-center mb-12 md:mb-16">
           <HeroEyebrow className="mb-4 mx-auto w-fit">The platform</HeroEyebrow>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white leading-tight max-w-3xl mx-auto">

--- a/new-landing/src/polymet/components/genezio-proof-section.tsx
+++ b/new-landing/src/polymet/components/genezio-proof-section.tsx
@@ -46,7 +46,7 @@ export function GenezioProofSection() {
     <section className="relative py-24 md:py-32 bg-[#050506] overflow-hidden">
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
 
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
         <div className="max-w-3xl mx-auto text-center mb-14 md:mb-20">
           <HeroEyebrow className="mb-6 mx-auto w-fit">The proof</HeroEyebrow>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-6 leading-tight">

--- a/new-landing/src/polymet/components/genezio-robot-reader-section.tsx
+++ b/new-landing/src/polymet/components/genezio-robot-reader-section.tsx
@@ -20,7 +20,7 @@ export function GenezioRobotReaderSection() {
     <section className="relative py-24 md:py-32 bg-[#0E0E10] overflow-hidden">
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
 
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
         <div className="text-center mb-12 md:mb-16">
           <HeroEyebrow className="mb-6 mx-auto w-fit">The twist</HeroEyebrow>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white leading-tight max-w-4xl mx-auto">

--- a/new-landing/src/polymet/components/genezio-shift-section.tsx
+++ b/new-landing/src/polymet/components/genezio-shift-section.tsx
@@ -22,7 +22,7 @@ export function GenezioShiftSection() {
     <section className="relative py-24 md:py-32 bg-[#050506] overflow-hidden">
       <div className="absolute inset-0 bg-gradient-to-b from-[#050506] via-[#0A0A0F] to-[#050506]" />
 
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16 relative z-10">
         <div className="text-center mb-14 md:mb-16">
           <HeroEyebrow className="mb-6">The shift</HeroEyebrow>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white leading-tight max-w-3xl mx-auto">

--- a/new-landing/src/polymet/components/genezio-testimonial-section.tsx
+++ b/new-landing/src/polymet/components/genezio-testimonial-section.tsx
@@ -4,7 +4,7 @@ import bcrLogo from "../../assets/bcr.svg";
 export function GenezioTestimonialSection() {
     return (
         <section className="relative py-20 md:py-32 bg-[#050506]">
-            <div className="container mx-auto px-6 max-w-7xl">
+            <div className="container mx-auto px-6 max-w-6xl">
                 {/* Main Testimonial Card */}
                 <div className="relative bg-gradient-to-br from-[#0E0E10] to-[#1A1A1F] border border-white/5 rounded-3xl overflow-hidden">
                     {/* Gradient Overlay */}

--- a/new-landing/src/polymet/components/genezio-trust-section.tsx
+++ b/new-landing/src/polymet/components/genezio-trust-section.tsx
@@ -87,7 +87,7 @@ export function GenezioTrustSection() {
 
   return (
     <section className="py-12 md:py-20 bg-[#050506] border-t border-white/10 relative">
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         <p className="text-center text-xs md:text-sm text-white/60 uppercase tracking-[0.2em] mb-8 md:mb-12 font-medium">
           Trusted by teams at Fortune 500 companies
         </p>

--- a/new-landing/src/polymet/components/industry-leaderboard-banner.tsx
+++ b/new-landing/src/polymet/components/industry-leaderboard-banner.tsx
@@ -9,7 +9,7 @@ export function IndustryLeaderboardBanner() {
 
   return (
     <div className="relative mt-16 bg-white/5 border-b border-white/10 backdrop-blur-sm">
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16 py-3.5">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16 py-3.5">
         <div className="flex items-center justify-center gap-3">
           {/* Message */}
           <div className="flex items-center gap-2 text-sm">

--- a/new-landing/src/polymet/components/lead-gen-actionable-insights.tsx
+++ b/new-landing/src/polymet/components/lead-gen-actionable-insights.tsx
@@ -44,7 +44,7 @@ export function LeadGenActionableInsights() {
 
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-white/[0.04] via-transparent to-transparent" />
 
-      <div className="relative max-w-7xl mx-auto px-6 sm:px-8 lg:px-16">
+      <div className="relative max-w-6xl mx-auto px-6 sm:px-8 lg:px-16">
         {/* Section Header */}
         <div className="text-center mb-12 sm:mb-16">
           <HeroEyebrow className="mb-6">Actionable Insights</HeroEyebrow>

--- a/new-landing/src/polymet/components/lead-gen-data-sources.tsx
+++ b/new-landing/src/polymet/components/lead-gen-data-sources.tsx
@@ -52,7 +52,7 @@ export function LeadGenDataSources() {
       {/* Background Elements */}
       <div className="absolute inset-0 bg-gradient-to-b from-transparent via-white/10 to-transparent" />
 
-      <div className="relative max-w-7xl mx-auto px-6 sm:px-8 lg:px-16">
+      <div className="relative max-w-6xl mx-auto px-6 sm:px-8 lg:px-16">
         {/* Section Header */}
         <div className="text-center mb-12 sm:mb-16">
           <HeroEyebrow className="mb-6">Powered by Your Data</HeroEyebrow>

--- a/new-landing/src/polymet/components/lead-gen-hero.tsx
+++ b/new-landing/src/polymet/components/lead-gen-hero.tsx
@@ -62,7 +62,7 @@ export function LeadGenHero() {
         {/* Grid Pattern */}
         <div className="absolute inset-0 bg-[linear-gradient(to_right,#ffffff05_1px,transparent_1px),linear-gradient(to_bottom,#ffffff05_1px,transparent_1px)] bg-[size:4rem_4rem]" />
 
-        <div className="relative max-w-7xl mx-auto px-6 sm:px-8 lg:px-16 py-12 sm:py-20 w-full">
+        <div className="relative max-w-6xl mx-auto px-6 sm:px-8 lg:px-16 py-12 sm:py-20 w-full">
           <div className="grid lg:grid-cols-2 gap-8 lg:gap-12 items-center">
             {/* Left Content */}
             <div className="space-y-6 sm:space-y-8">

--- a/new-landing/src/polymet/components/lead-gen-intelligence.tsx
+++ b/new-landing/src/polymet/components/lead-gen-intelligence.tsx
@@ -62,7 +62,7 @@ export function LeadGenIntelligence() {
       {/* Background Elements */}
       <div className="absolute inset-0 bg-gradient-to-b from-transparent via-white/10 to-transparent" />
 
-      <div className="relative max-w-7xl mx-auto px-6 sm:px-8 lg:px-16">
+      <div className="relative max-w-6xl mx-auto px-6 sm:px-8 lg:px-16">
         {/* Section Header */}
         <div className="text-center mb-12 sm:mb-16">
           <HeroEyebrow className="mb-6">Deep Intelligence</HeroEyebrow>

--- a/new-landing/src/polymet/components/lead-gen-personas.tsx
+++ b/new-landing/src/polymet/components/lead-gen-personas.tsx
@@ -55,7 +55,7 @@ export function LeadGenPersonas() {
 
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,_var(--tw-gradient-stops))] from-zinc-500/5 via-transparent to-transparent" />
 
-      <div className="relative max-w-7xl mx-auto px-6 sm:px-8 lg:px-16">
+      <div className="relative max-w-6xl mx-auto px-6 sm:px-8 lg:px-16">
         {/* Section Header */}
         <div className="text-center mb-12 sm:mb-16">
           <HeroEyebrow className="mb-6">Persona-Based Analysis</HeroEyebrow>

--- a/new-landing/src/polymet/components/multi-turn-testing.tsx
+++ b/new-landing/src/polymet/components/multi-turn-testing.tsx
@@ -102,7 +102,7 @@ export function MultiTurnTesting() {
       {/* Background Elements */}
       <div className="absolute inset-0 bg-gradient-to-b from-zinc-500/5 via-transparent to-zinc-500/5" />
 
-      <div className="relative max-w-7xl mx-auto px-6 sm:px-8 lg:px-16">
+      <div className="relative max-w-6xl mx-auto px-6 sm:px-8 lg:px-16">
         {/* Section Header */}
         <div className="text-center mb-12 sm:mb-16">
           <HeroEyebrow className="mb-6">Multi-Turn Testing</HeroEyebrow>

--- a/new-landing/src/polymet/pages/blog-author.tsx
+++ b/new-landing/src/polymet/pages/blog-author.tsx
@@ -104,7 +104,7 @@ function BlogAuthor() {
       <div className="min-h-screen bg-[#050506]">
         {/* Back Button */}
         <div className="px-6 pt-8">
-          <div className="max-w-7xl mx-auto">
+          <div className="max-w-6xl mx-auto">
             <Link
               to="/blog/"
               className="inline-flex items-center gap-2 text-white/60 hover:text-white transition-colors"
@@ -169,7 +169,7 @@ function BlogAuthor() {
 
         {/* Author's Articles */}
         <section className="px-6 pb-32">
-          <div className="max-w-7xl mx-auto">
+          <div className="max-w-6xl mx-auto">
             <h2 className="text-2xl font-bold text-white mb-8">
               Articles by {author.name}
             </h2>

--- a/new-landing/src/polymet/pages/blog-post.tsx
+++ b/new-landing/src/polymet/pages/blog-post.tsx
@@ -675,7 +675,7 @@ export function BlogPost() {
       />
       {/* Back Button */}
       <div className="pt-24 pb-8">
-        <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+        <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
           <a
             href={`${sectionBasePath}/`}
             className="inline-flex items-center gap-2 text-white/60 hover:text-white transition-colors group"
@@ -689,7 +689,7 @@ export function BlogPost() {
 
       {/* Article Header */}
       <article className="pb-32">
-        <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+        <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
           {/* Post Type & Category Badges */}
           <div className="flex flex-wrap items-center gap-3 mb-6">
             {post.postType && (
@@ -1014,7 +1014,7 @@ export function BlogPost() {
 
       {/* CTA Section */}
       <section className="pb-32">
-        <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+        <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
           <div className="relative bg-white/5 border border-white/10 rounded-2xl p-12 overflow-hidden">
             {/* Background gradient */}
             <div className="absolute inset-0 bg-gradient-to-br from-zinc-600/10 via-white/10 to-transparent" />

--- a/new-landing/src/polymet/pages/blog.tsx
+++ b/new-landing/src/polymet/pages/blog.tsx
@@ -95,7 +95,7 @@ export function Blog() {
         {/* Featured */}
         {featuredPosts.length > 0 && (
           <section className="px-6 md:px-8 lg:px-16 pb-16 md:pb-20">
-            <div className="max-w-7xl mx-auto">
+            <div className="max-w-6xl mx-auto">
               <SectionLabel>Featured</SectionLabel>
 
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -166,7 +166,7 @@ export function Blog() {
 
         {/* All posts */}
         <section className="px-6 md:px-8 lg:px-16 pb-32">
-          <div className="max-w-7xl mx-auto">
+          <div className="max-w-6xl mx-auto">
             <SectionLabel>AI visibility &amp; recommendation deep dives</SectionLabel>
 
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/new-landing/src/polymet/pages/content-analysis.tsx
+++ b/new-landing/src/polymet/pages/content-analysis.tsx
@@ -108,7 +108,7 @@ function TwoModes() {
   return (
     <section className="py-16 md:py-32 bg-[#0E0E10] relative">
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         <div className="text-center mb-12 md:mb-16">
           <HeroEyebrow className="mb-4 mx-auto w-fit">Two moments, one system</HeroEyebrow>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold mb-6 leading-tight text-white max-w-3xl mx-auto">
@@ -170,7 +170,7 @@ function ReportAnatomy() {
 
   return (
     <section className="py-16 md:py-32 bg-[#050506] relative">
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         <div className="text-center mb-12 md:mb-16">
           <HeroEyebrow className="mb-4 mx-auto w-fit">What one analysis looks like</HeroEyebrow>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold mb-6 leading-tight text-white max-w-3xl mx-auto">
@@ -283,7 +283,7 @@ function InsideAnalysis() {
   return (
     <section className="py-16 md:py-32 bg-[#0E0E10] relative">
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         <div className="text-center mb-12 md:mb-16">
           <HeroEyebrow className="mb-4 mx-auto w-fit">Inside a check</HeroEyebrow>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold mb-6 leading-tight text-white max-w-3xl mx-auto">

--- a/new-landing/src/polymet/pages/content-hub.tsx
+++ b/new-landing/src/polymet/pages/content-hub.tsx
@@ -96,7 +96,7 @@ function MeasurementToBrief() {
   return (
     <section className="py-16 md:py-32 bg-[#0E0E10] relative">
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         <div className="text-center mb-12 md:mb-20">
           <HeroEyebrow className="mb-4 mx-auto w-fit">From measurement to action</HeroEyebrow>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold mb-6 leading-tight text-white max-w-3xl mx-auto">
@@ -178,7 +178,7 @@ function BriefAnatomy() {
 
   return (
     <section className="py-16 md:py-32 bg-[#050506] relative">
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-center">
           {/* Text */}
           <div>
@@ -254,7 +254,7 @@ function BriefsVsDirect() {
   return (
     <section className="py-16 md:py-32 bg-[#0E0E10] relative">
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         <div className="text-center mb-12 md:mb-16">
           <HeroEyebrow className="mb-4 mx-auto w-fit">Two ways to ship</HeroEyebrow>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold mb-6 leading-tight text-white max-w-3xl mx-auto">
@@ -361,7 +361,7 @@ function PlanLikeMedia() {
 
   return (
     <section className="py-16 md:py-32 bg-[#050506] relative">
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         <div className="text-center mb-12 md:mb-16">
           <HeroEyebrow className="mb-4 mx-auto w-fit">The playbook</HeroEyebrow>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold mb-6 leading-tight text-white max-w-3xl mx-auto">

--- a/new-landing/src/polymet/pages/in-chat-shopping.tsx
+++ b/new-landing/src/polymet/pages/in-chat-shopping.tsx
@@ -61,7 +61,7 @@ function ShoppingHero() {
     <section className="relative overflow-hidden bg-[#050506] pt-32 pb-20 md:pt-40 md:pb-28">
       <div className="absolute inset-0 bg-gradient-to-b from-[#050506] via-[#0A0A0F] to-[#050506]" />
 
-      <div className="relative z-10 max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="relative z-10 max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-center">
           <div className="text-center lg:text-left">
             <HeroEyebrow className="mb-6">In-Chat Shopping · AI Product Intelligence</HeroEyebrow>
@@ -179,7 +179,7 @@ function WhatWeAnalyze() {
   return (
     <section className="py-16 md:py-32 bg-[#0E0E10] relative">
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         <div className="text-center mb-12 md:mb-16">
           <HeroEyebrow className="mb-4 mx-auto w-fit">What we analyze</HeroEyebrow>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white leading-tight max-w-3xl mx-auto">
@@ -257,7 +257,7 @@ function WhatItReveals() {
   ];
   return (
     <section className="py-16 md:py-32 bg-[#050506] relative">
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         <div className="text-center mb-12 md:mb-16">
           <HeroEyebrow className="mb-4 mx-auto w-fit">What it reveals</HeroEyebrow>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white leading-tight max-w-3xl mx-auto">
@@ -306,7 +306,7 @@ function ProductLevelView() {
   return (
     <section className="py-16 md:py-32 bg-[#0E0E10] relative">
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         <div className="text-center mb-12 md:mb-16">
           <HeroEyebrow className="mb-4 mx-auto w-fit">Product-level view</HeroEyebrow>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white leading-tight max-w-3xl mx-auto">
@@ -415,7 +415,7 @@ function MarketplacePerformance() {
   ];
   return (
     <section className="py-16 md:py-32 bg-[#050506] relative">
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-center">
           <div>
             <HeroEyebrow className="mb-4 mx-auto w-fit">Marketplace performance</HeroEyebrow>

--- a/new-landing/src/polymet/pages/mcp.tsx
+++ b/new-landing/src/polymet/pages/mcp.tsx
@@ -25,7 +25,7 @@ function McpHero() {
   return (
     <section className="relative overflow-hidden bg-[#050506] pt-32 pb-20 md:pt-44 md:pb-28">
 
-      <div className="relative z-10 max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="relative z-10 max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         <div className="grid grid-cols-1 lg:grid-cols-[1.05fr_0.95fr] gap-14 lg:gap-20 items-center">
           {/* Left */}
           <div className="text-center lg:text-left">
@@ -196,7 +196,7 @@ function Capabilities() {
 
   return (
     <section className="py-16 md:py-28 bg-[#050506] relative">
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         <div className="text-center mb-12 md:mb-16 max-w-3xl mx-auto">
           <HeroEyebrow className="mb-6 mx-auto w-fit">What you can do</HeroEyebrow>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-6 leading-tight">

--- a/new-landing/src/polymet/pages/methodology.tsx
+++ b/new-landing/src/polymet/pages/methodology.tsx
@@ -101,7 +101,7 @@ function HowWeMeasure() {
   return (
     <section className="relative bg-[#0E0E10] py-20 md:py-28">
       <Hairline />
-      <div className="relative z-10 max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="relative z-10 max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         <div className="max-w-2xl mb-14 md:mb-16">
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold tracking-[-0.02em] text-white leading-tight">
             How we measure

--- a/new-landing/src/polymet/pages/research.tsx
+++ b/new-landing/src/polymet/pages/research.tsx
@@ -43,7 +43,7 @@ export function Research() {
         <section className="relative pt-32 pb-20 px-6 overflow-hidden">
           <div className="absolute inset-0 bg-gradient-to-b from-white/[0.04] via-white/10 to-transparent" />
 
-          <div className="relative max-w-7xl mx-auto">
+          <div className="relative max-w-6xl mx-auto">
             <div className="text-center max-w-3xl mx-auto mb-12">
               <HeroEyebrow className="mb-6">Original Research</HeroEyebrow>
 
@@ -74,7 +74,7 @@ export function Research() {
         </section>
 
         <section className="px-6 pb-32">
-          <div className="max-w-7xl mx-auto">
+          <div className="max-w-6xl mx-auto">
             {filteredPosts.length > 0 ? (
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                 {filteredPosts.map((post) => {

--- a/new-landing/src/polymet/pages/security.tsx
+++ b/new-landing/src/polymet/pages/security.tsx
@@ -286,7 +286,7 @@ function DomainsSection() {
     <section className="relative bg-[#050506] py-20 md:py-28">
       <Hairline />
 
-      <div className="relative z-10 max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="relative z-10 max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         <div className="max-w-2xl mb-14 md:mb-20">
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold tracking-[-0.02em] text-white leading-tight">
             Security built into every layer

--- a/new-landing/src/polymet/pages/website-analyzer.tsx
+++ b/new-landing/src/polymet/pages/website-analyzer.tsx
@@ -290,7 +290,7 @@ function WhatItChecks() {
 
   return (
     <section className="py-16 md:py-28 bg-[#050506] relative">
-      <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-16">
+      <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
         <div className="text-center mb-12 md:mb-16">
           <HeroEyebrow className="mb-4 mx-auto w-fit">What we check</HeroEyebrow>
           <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold mb-6 leading-tight text-white max-w-3xl mx-auto">

--- a/new-landing/src/polymet/v2/components/genezio-features-section.tsx
+++ b/new-landing/src/polymet/v2/components/genezio-features-section.tsx
@@ -49,7 +49,7 @@ export function GenezioFeaturesSection() {
   return (
     <section className="relative py-20 md:py-32">
       <div className="px-6 md:px-8 lg:px-12">
-        <div className="max-w-7xl mx-auto">
+        <div className="max-w-6xl mx-auto">
           {/* Header */}
           <div className="text-center space-y-4 mb-20">
             <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold">


### PR DESCRIPTION
Replaces `max-w-7xl` with `max-w-6xl` across all pages and components (header, footer, homepage, blog article, blog listing, and every other page) for one consistent, slightly narrower container width site-wide — matching the requested Profound-like proportions.

Verified: homepage, blog listing, and blog article all render at the same width with nav/content/footer edges aligned; no layout breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmfAfNKnLE9VKhFLuaCYdH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmfAfNKnLE9VKhFLuaCYdH)_