### PR TITLE
Align blog/research/author listing cards to nav width

### DIFF
--- a/new-landing/public/rss.xml
+++ b/new-landing/public/rss.xml
@@ -5,7 +5,7 @@
     <link>https://genezio.com/blog/</link>
     <description>The platform built for Generative Search and Answer Engine Optimization.</description>
     <language>en-us</language>
-    <lastBuildDate>Wed, 26 Aug 2026 18:53:09 GMT</lastBuildDate>
+    <lastBuildDate>Wed, 26 Aug 2026 19:00:44 GMT</lastBuildDate>
     <atom:link href="https://genezio.com/rss.xml" rel="self" type="application/rss+xml" />
     
     <item>

--- a/new-landing/src/polymet/pages/blog-author.tsx
+++ b/new-landing/src/polymet/pages/blog-author.tsx
@@ -103,8 +103,8 @@ function BlogAuthor() {
       />
       <div className="min-h-screen bg-[#050506]">
         {/* Back Button */}
-        <div className="px-6 pt-8">
-          <div className="max-w-6xl mx-auto">
+        <div className="pt-8">
+          <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
             <Link
               to="/blog/"
               className="inline-flex items-center gap-2 text-white/60 hover:text-white transition-colors"
@@ -168,8 +168,8 @@ function BlogAuthor() {
         </section>
 
         {/* Author's Articles */}
-        <section className="px-6 pb-32">
-          <div className="max-w-6xl mx-auto">
+        <section className="pb-32">
+          <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
             <h2 className="text-2xl font-bold text-white mb-8">
               Articles by {author.name}
             </h2>

--- a/new-landing/src/polymet/pages/blog.tsx
+++ b/new-landing/src/polymet/pages/blog.tsx
@@ -94,8 +94,8 @@ export function Blog() {
 
         {/* Featured */}
         {featuredPosts.length > 0 && (
-          <section className="px-6 md:px-8 lg:px-16 pb-16 md:pb-20">
-            <div className="max-w-6xl mx-auto">
+          <section className="pb-16 md:pb-20">
+            <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
               <SectionLabel>Featured</SectionLabel>
 
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -165,8 +165,8 @@ export function Blog() {
         )}
 
         {/* All posts */}
-        <section className="px-6 md:px-8 lg:px-16 pb-32">
-          <div className="max-w-6xl mx-auto">
+        <section className="pb-32">
+          <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
             <SectionLabel>AI visibility &amp; recommendation deep dives</SectionLabel>
 
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/new-landing/src/polymet/pages/research.tsx
+++ b/new-landing/src/polymet/pages/research.tsx
@@ -73,8 +73,8 @@ export function Research() {
           </div>
         </section>
 
-        <section className="px-6 pb-32">
-          <div className="max-w-6xl mx-auto">
+        <section className="pb-32">
+          <div className="max-w-6xl mx-auto px-6 md:px-8 lg:px-16">
             {filteredPosts.length > 0 ? (
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                 {filteredPosts.map((post) => {


### PR DESCRIPTION
The blog, research, and author listing pages put horizontal padding on the `<section>` (outside `max-w-6xl`), which made their content ~64px wider than the header/footer on each side. Moved the padding inside the `max-w-6xl` container (`px-6 md:px-8 lg:px-16`), matching the homepage/header model, so the cards align with the nav and footer edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmfAfNKnLE9VKhFLuaCYdH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmfAfNKnLE9VKhFLuaCYdH)_