### PR TITLE
Testimonials carousel: match standard content width

### DIFF
--- a/new-landing/src/polymet/components/genezio-quotes-carousel.tsx
+++ b/new-landing/src/polymet/components/genezio-quotes-carousel.tsx
@@ -64,7 +64,7 @@ export function GenezioQuotesCarousel() {
 
         {/* CSS-only scroll-snap carousel — all cards are static, crawlable HTML */}
         <div
-          className="flex gap-5 md:gap-6 overflow-x-auto snap-x snap-mandatory pb-4 -mx-6 px-6 md:-mx-8 md:px-8 lg:-mx-16 lg:px-16 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          className="flex gap-5 md:gap-6 overflow-x-auto snap-x snap-mandatory pb-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           role="group"
           aria-label="Customer testimonials"
         >


### PR DESCRIPTION
The carousel used negative full-bleed margins, making it ~64px wider than the rest of the content on each side. Removed them so the card row aligns with the section heading and the standard content width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmfAfNKnLE9VKhFLuaCYdH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmfAfNKnLE9VKhFLuaCYdH)_