### PR TITLE
Retitle comparison post (alternatives angle)

### DIFF
--- a/new-landing/public/rss.xml
+++ b/new-landing/public/rss.xml
@@ -5,11 +5,11 @@
     <link>https://genezio.com/blog/</link>
     <description>The platform built for Generative Search and Answer Engine Optimization.</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 27 Aug 2026 08:25:57 GMT</lastBuildDate>
+    <lastBuildDate>Thu, 27 Aug 2026 09:35:51 GMT</lastBuildDate>
     <atom:link href="https://genezio.com/rss.xml" rel="self" type="application/rss+xml" />
     
     <item>
-        <title><![CDATA[Why Enterprises Choose Genezio Over Profound, Semrush, and Bluefish for AI Visibility]]></title>
+        <title><![CDATA[Profound, Semrush & Bluefish Alternatives: How Genezio Compares]]></title>
         <link>https://genezio.com/blog/genezio-vs-profound-semrush-bluefish/</link>
         <guid isPermaLink="true">https://genezio.com/blog/genezio-vs-profound-semrush-bluefish/</guid>
         <description><![CDATA[How Genezio compares with Profound, Semrush, and Bluefish for enterprise AI visibility, recommendation share, citations, multi-market tracking, and pricing.]]></description>

--- a/new-landing/src/posts/genezio-vs-profound-semrush-bluefish.md
+++ b/new-landing/src/posts/genezio-vs-profound-semrush-bluefish.md
@@ -1,6 +1,6 @@
 ---
-title: "Why Enterprises Choose Genezio Over Profound, Semrush, and Bluefish for AI Visibility"
-metaTitle: "Genezio vs Profound, Semrush & Bluefish for AI Visibility"
+title: "Profound, Semrush & Bluefish Alternatives: How Genezio Compares"
+metaTitle: "Genezio vs Profound, Semrush & Bluefish (2026)"
 date: 2026-08-27
 tags:
   - AI


### PR DESCRIPTION
Updates the comparison post's title per feedback:
- **Display title (H1):** "Profound, Semrush & Bluefish Alternatives: How Genezio Compares" (captures "[tool] alternatives" buyer-intent searches, less self-promotional)
- **metaTitle:** "Genezio vs Profound, Semrush & Bluefish (2026)" (compact, all brand names + "vs")
- Slug/URL unchanged (`/blog/genezio-vs-profound-semrush-bluefish/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmfAfNKnLE9VKhFLuaCYdH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmfAfNKnLE9VKhFLuaCYdH)_